### PR TITLE
Fixed NPE when LOTL loading fails

### DIFF
--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLValidationJob.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLValidationJob.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 
 import javax.annotation.PostConstruct;
 
+import eu.europa.esig.dss.DSSException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -170,7 +171,11 @@ public class TSLValidationJob {
 			resultLoaderLOTL = result.get();
 		} catch (Exception e) {
 			logger.error("Unable to load the LOTL : " + e.getMessage(), e);
-			return;
+			throw new DSSException("Unable to load the LOTL : " + e.getMessage());
+		}
+		if(resultLoaderLOTL.getContent() == null) {
+			logger.error("Unable to load the LOTL: content is empty");
+			throw new DSSException("Unable to load the LOTL: content is empty");
 		}
 
 		TSLValidationModel europeanModel = null;


### PR DESCRIPTION
This modification fixes NullPointerException when LOTL loading fails and throws a specific DSS exception so such situations could be handled gracefully.

```
01.12.2015 14:26:06.204 WARN  [pool-197-thread-7] [e.e.esig.dss.tsl.service.TSLLoader.call:58] - Unable to load 'http://references.modernisation.gouv.fr/sites/default/files/TSL-FR.xml' : org.apache.http.conn.HttpHostConnectException: Connect to references.modernisation.gouv.fr:80 [references.modernisation.gouv.fr/217.74.104.3] failed: Operation timed out
01.12.2015 14:26:06.205 ERROR [main] [e.e.e.d.tsl.service.TSLValidationJob.analyzeCountryPointers:243] - Unable to load/parse TSL : null
  java.lang.NullPointerException: null
    at java.security.MessageDigest.update(MessageDigest.java:335)
    at java.security.MessageDigest.digest(MessageDigest.java:410)
    at eu.europa.esig.dss.DSSUtils.digest(DSSUtils.java:587)
    at eu.europa.esig.dss.tsl.service.TSLRepository.getSHA256(TSLRepository.java:270)
    at eu.europa.esig.dss.tsl.service.TSLRepository.storeInCache(TSLRepository.java:209)
    at eu.europa.esig.dss.tsl.service.TSLValidationJob.analyzeCountryPointers(TSLValidationJob.java:226)
    at eu.europa.esig.dss.tsl.service.TSLValidationJob.refresh(TSLValidationJob.java:203)
```