### PR TITLE
Enable DSA/ECDSA signing when signature is not ASN1 encoded

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/DSSSignatureUtils.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/DSSSignatureUtils.java
@@ -56,7 +56,7 @@ public final class DSSSignatureUtils {
 			return signatureValue;
 		} catch (IOException e) {
 
-			throw new DSSException(e);
+			return signatureValue;
 		}
 	}
 


### PR DESCRIPTION
Enable document signing for DSA and ECDSA algorithms when the signature is not ASN1 encoded