### PR TITLE
Made ServiceInfoStatus serializable

### DIFF
--- a/dss-model/src/main/java/eu/europa/esig/dss/tsl/ServiceInfoStatus.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/tsl/ServiceInfoStatus.java
@@ -1,8 +1,9 @@
 package eu.europa.esig.dss.tsl;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class ServiceInfoStatus {
+public class ServiceInfoStatus implements Serializable{
 
 	/**
 	 * <tsl:TrustServiceProvider><tsl:TSPServices><tsl:TSPService><tsl:ServiceInformation><tsl:ServiceStatus>


### PR DESCRIPTION
This modification makes ServiceInfoStatus class serializable. This is needed for serializing TSL.