### PR TITLE
Restored createDocument method

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/DSSXMLUtils.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/DSSXMLUtils.java
@@ -776,6 +776,31 @@ public final class DSSXMLUtils {
 	}
 
 	/**
+	 * Creates a DOM Document object of the specified type with its document element.
+	 *
+	 * @param namespaceURI  the namespace URI of the document element to create or null
+	 * @param qualifiedName the qualified name of the document element to be created or null
+	 * @param element       document {@code Element}
+	 * @return {@code Document}
+	 */
+	public static Document createDocument(final String namespaceURI, final String qualifiedName, final Element element) {
+		ensureDocumentBuilder();
+
+		DOMImplementation domImpl;
+		try {
+			domImpl = dbFactory.newDocumentBuilder().getDOMImplementation();
+		} catch (ParserConfigurationException e) {
+			throw new DSSException(e);
+		}
+		final Document newDocument = domImpl.createDocument(namespaceURI, qualifiedName, null);
+		final Element newElement = newDocument.getDocumentElement();
+		newDocument.adoptNode(element);
+		newElement.appendChild(element);
+
+		return newDocument;
+	}
+
+	/**
 	 * Converts a given {@code Date} to a new {@code XMLGregorianCalendar}.
 	 *
 	 * @param date


### PR DESCRIPTION
This modification restores DSSXMLUtils.createDocument method that was previously removed as "dead code" in this commit
https://github.com/esig/dss/commit/fbe0367274c00c8d1ec94910e0e0459898488f4e#diff-bfe9571bf75caeaed6e15fe89a173d70L751

We use that method to transform XAdES XML document into byte array. It would be good if it could remain in DSS.