### PR TITLE
Reverted unnecessary removal of policy id prefix

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/validation/XAdESSignature.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/validation/XAdESSignature.java
@@ -634,11 +634,7 @@ public class XAdESSignature extends DefaultAdvancedSignature {
 			final Element policyId = DSSXMLUtils.getElement(policyIdentifier, xPathQueryHolder.XPATH__POLICY_ID);
 			if (policyId != null) {
 				// Explicit policy
-				String policyIdString = policyId.getTextContent();
-				// urn:oid:1.2.3 --> 1.2.3
-				if (policyIdString.indexOf(':') >= 0) {
-					policyIdString = policyIdString.substring(policyIdString.lastIndexOf(':') + 1);
-				}
+				final String policyIdString = policyId.getTextContent();
 				final SignaturePolicy signaturePolicy = new SignaturePolicy(policyIdString);
 				final Node policyDigestMethod = DSSXMLUtils.getNode(policyIdentifier, xPathQueryHolder.XPATH__POLICY_DIGEST_METHOD);
 				final String policyDigestMethodString = policyDigestMethod.getTextContent();

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/validation/XAdESValidationTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/validation/XAdESValidationTest.java
@@ -37,7 +37,7 @@ import eu.europa.esig.dss.x509.SignaturePolicy;
 
 public class XAdESValidationTest {
 
-	private static final String POLICY_ID = "1.3.6.1.4.1.10015.1000.3.2.1";
+	private static final String POLICY_ID = "urn:oid:1.3.6.1.4.1.10015.1000.3.2.1";
 	private static final String POLICY_URL = "http://spuri.test";
 	private static final String POLICY_DIGEST_VALUE = "3Tl1oILSvOAWomdI9VeWV6IA/32eSXRUri9kPEz1IVs=";
 


### PR DESCRIPTION
This modification reverts the change that was done to remove policy id prefix. For example, "urn:oid:1.2.3" policy id was changed to "1.2.3".

Estonian BDOC containers contain policy id with value "urn:oid:1.3.6.1.4.1.10015.1000.3.2.1". If the prefix "urn:oid:" would be removed, then the BDOC containers validation would be broken.

The reverted change comes from this commit: https://github.com/esig/dss/commit/329910a9ac24ecbbff2b411b1d97034723d2de44#diff-f65ad7d4afec3524299b85446c4e1f3dR648
