### PR TITLE
Fixed Java 6 support, the diamond operator <>

### DIFF
--- a/dss-pades/src/test/java/eu/europa/esig/dss/pades/TwoPAdESSigniatureMustHaveDifferentIdTest.java
+++ b/dss-pades/src/test/java/eu/europa/esig/dss/pades/TwoPAdESSigniatureMustHaveDifferentIdTest.java
@@ -71,7 +71,7 @@ public class TwoPAdESSigniatureMustHaveDifferentIdTest {
 
 		List<String> signatureIdList = reports.getSimpleReport().getSignatureIdList();
 
-		Assert.assertEquals(2, new HashSet<>(reports.getSimpleReport().getSignatureIdList()).size());
+		Assert.assertEquals(2, new HashSet<String>(reports.getSimpleReport().getSignatureIdList()).size());
 		Assert.assertNotEquals(signatureIdList.get(0), signatureIdList.get(1));
 
 	}


### PR DESCRIPTION
This modification fixes Java 6 support by replacing empty diamond operator <> by generics <String>. Diamond operators were added to Java 7.

We don't need Java 6 support, but somehow it broke the build anyway.