### PR TITLE
Fixed nullpointer if revocation date is not available

### DIFF
--- a/validation-policy/src/main/java/eu/europa/esig/dss/validation/process/vpfltvd/checks/RevocationDateAfterBestSignatureTimeCheck.java
+++ b/validation-policy/src/main/java/eu/europa/esig/dss/validation/process/vpfltvd/checks/RevocationDateAfterBestSignatureTimeCheck.java
@@ -30,7 +30,11 @@ public class RevocationDateAfterBestSignatureTimeCheck extends ChainItem<XmlVali
 	@Override
 	protected boolean process() {
 		RevocationWrapper revocationData = certificate.getLatestRevocationData();
-		return revocationData.getRevocationDate().after(bestSignatureTime);
+		Date revocationDate = revocationData.getRevocationDate();
+		if(revocationDate == null) {
+			return true;
+		}
+		return revocationDate.after(bestSignatureTime);
 	}
 
 	@Override


### PR DESCRIPTION
This modification fixes a NullPointerException that was thrown if OCSP response status is revoked or unknown, but revocation date is not set.