### PR TITLE
Reduced exception stack trace logging for xades signature validation

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/validation/XAdESSignature.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/validation/XAdESSignature.java
@@ -1376,7 +1376,7 @@ public class XAdESSignature extends DefaultAdvancedSignature {
 						break;
 					}
 				} catch (XMLSignatureException e) {
-					LOG.warn("Exception when validating signature: ", e);
+					LOG.warn("Exception when validating signature: " + e.getMessage());
 					signatureCryptographicVerification.setErrorMessage(e.getMessage());
 				}
 			}
@@ -1406,7 +1406,8 @@ public class XAdESSignature extends DefaultAdvancedSignature {
 			signatureCryptographicVerification.setSignatureIntact(coreValidity);
 		} catch (Exception e) {
 
-			LOG.error(e.getMessage(), e);
+			LOG.error(e.getMessage());
+			LOG.debug(e.getMessage(), e);
 			StackTraceElement[] stackTrace = e.getStackTrace();
 			final String name = XAdESSignature.class.getName();
 			int lineNumber = 0;


### PR DESCRIPTION
This modification reduces stack trace logging if there are any XAdES signature validation errors.

The log files would otherwise get filled with too much stack trace information.