### PR TITLE
Signatures supported by a TL certificate

### DIFF
--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/SignatureValidationContext.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/SignatureValidationContext.java
@@ -20,7 +20,6 @@
  */
 package eu.europa.esig.dss.validation;
 
-import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -40,7 +39,6 @@ import eu.europa.esig.dss.DSSASN1Utils;
 import eu.europa.esig.dss.DSSException;
 import eu.europa.esig.dss.DSSUtils;
 import eu.europa.esig.dss.client.http.DataLoader;
-import eu.europa.esig.dss.utils.Utils;
 import eu.europa.esig.dss.x509.CertificatePool;
 import eu.europa.esig.dss.x509.CertificateSourceType;
 import eu.europa.esig.dss.x509.CertificateToken;
@@ -270,21 +268,6 @@ public class SignatureValidationContext implements ValidationContext {
 		return null;
 	}
 
-	private CertificateToken getCertFromPool(final Token token) {
-		if (token instanceof CertificateToken) {
-			final List<CertificateToken> certList = validationCertificatePool.get(token.getX500Principal());
-			if (Utils.isCollectionNotEmpty(certList)) {
-				final PublicKey pubKey1 = ((CertificateToken) token).getPublicKey();
-				for (final CertificateToken certToken : certList) {
-					if (token.equals(certToken) && certToken.getPublicKey().equals(pubKey1)) {
-						return certToken;
-					}
-				}
-			}
-		}
-		return null;
-	}
-	
 	/**
 	 * Adds a new token to the list of tokes to verify only if it was not already verified.
 	 *
@@ -383,15 +366,6 @@ public class SignatureValidationContext implements ValidationContext {
 			token = getNotYetVerifiedToken();
 			if (token != null) {
 
-				final CertificateToken certToken = getCertFromPool(token);
-				if ( certToken != null && certToken != token && token instanceof CertificateToken ) {
-					final CertificateToken token1 = (CertificateToken) token;
-					if ( Utils.isCollectionEmpty(token1.getAssociatedTSPS()) ) {
-						token1.copyServiceInfoFrom(certToken);
-						token1.copySourceTypeFrom(certToken);
-					}
-				}
-				
 				/**
 				 * Gets the issuer certificate of the Token and checks its signature
 				 */

--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/SignatureValidationContext.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/SignatureValidationContext.java
@@ -20,6 +20,7 @@
  */
 package eu.europa.esig.dss.validation;
 
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -39,6 +40,7 @@ import eu.europa.esig.dss.DSSASN1Utils;
 import eu.europa.esig.dss.DSSException;
 import eu.europa.esig.dss.DSSUtils;
 import eu.europa.esig.dss.client.http.DataLoader;
+import eu.europa.esig.dss.utils.Utils;
 import eu.europa.esig.dss.x509.CertificatePool;
 import eu.europa.esig.dss.x509.CertificateSourceType;
 import eu.europa.esig.dss.x509.CertificateToken;
@@ -268,6 +270,21 @@ public class SignatureValidationContext implements ValidationContext {
 		return null;
 	}
 
+	private CertificateToken getCertFromPool(final Token token) {
+		if (token instanceof CertificateToken) {
+			final List<CertificateToken> certList = validationCertificatePool.get(token.getX500Principal());
+			if (Utils.isCollectionNotEmpty(certList)) {
+				final PublicKey pubKey1 = ((CertificateToken) token).getPublicKey();
+				for (final CertificateToken certToken : certList) {
+					if (token.equals(certToken) && certToken.getPublicKey().equals(pubKey1)) {
+						return certToken;
+					}
+				}
+			}
+		}
+		return null;
+	}
+	
 	/**
 	 * Adds a new token to the list of tokes to verify only if it was not already verified.
 	 *
@@ -366,6 +383,15 @@ public class SignatureValidationContext implements ValidationContext {
 			token = getNotYetVerifiedToken();
 			if (token != null) {
 
+				final CertificateToken certToken = getCertFromPool(token);
+				if ( certToken != null && certToken != token && token instanceof CertificateToken ) {
+					final CertificateToken token1 = (CertificateToken) token;
+					if ( Utils.isCollectionEmpty(token1.getAssociatedTSPS()) ) {
+						token1.copyServiceInfoFrom(certToken);
+						token1.copySourceTypeFrom(certToken);
+					}
+				}
+				
 				/**
 				 * Gets the issuer certificate of the Token and checks its signature
 				 */

--- a/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
@@ -127,6 +127,7 @@ public class CertificateToken extends Token {
 		}
 
 		this.x509Certificate = x509Certificate;
+		this.x500Principal = x509Certificate.getSubjectX500Principal();
 		this.issuerX500Principal = x509Certificate.getIssuerX500Principal();
 		// The Algorithm OID is used and not the name {@code x509Certificate.getSigAlgName()}
 		this.signatureAlgorithm = SignatureAlgorithm.forOID(x509Certificate.getSigAlgOID());

--- a/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
@@ -606,4 +606,22 @@ public class CertificateToken extends Token {
 		return readableCertificate;
 	}
 
+	public void copySourceTypeFrom(final CertificateToken srcCertToken) {
+		final Set<CertificateSourceType> sources2 = srcCertToken.getSources();
+		if (sources2 != null) {
+			for (final CertificateSourceType cst : sources2) {
+				addSourceType(cst);
+			}
+		}
+	}
+
+	public void copyServiceInfoFrom(final CertificateToken srcCertToken) {
+		final Set<ServiceInfo> services2 = srcCertToken.getAssociatedTSPS();
+		if (services2 != null) {
+			for (final ServiceInfo serviceInfo : services2) {
+				addServiceInfo(serviceInfo);
+			}
+		}
+	}
+
 }

--- a/dss-model/src/main/java/eu/europa/esig/dss/x509/Token.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/x509/Token.java
@@ -48,6 +48,11 @@ public abstract class Token implements Serializable {
 	 */
 	protected X500Principal issuerX500Principal;
 
+	/**
+	 * The normalized {@link X500Principal} of this token (used for {@link CertificateToken}).
+	 */
+	protected X500Principal x500Principal = null;
+
 	/*
 	 * Indicates the token signature is valid.
 	 */
@@ -139,6 +144,15 @@ public abstract class Token implements Serializable {
 	 */
 	public X500Principal getIssuerX500Principal() {
 		return issuerX500Principal;
+	}
+
+	/**
+	 * Returns the {@code X500Principal} of the certificate in this token.
+	 *
+	 * @return
+	 */
+	public X500Principal getX500Principal() {
+		return x500Principal;
 	}
 
 	/**


### PR DESCRIPTION
Correctly fetch TL service info when validating **signatures supported by a certificate that is directly listed on the TL**. This is the case for almost all types of services except CA/QC, CA/PKC and possibly also ACA i.e., for all services where the TL lists the signing certificate itself (rather than the issuing certificate).

Implementation note: I assume we can't replace the signing CertificateToken (which is coming to SignatureValidationContext from outside) with the one constructed from the TL. This led me to copying the relevant information (the collections of ServiceInfo and CertificateSourceType) over. Please check:

1. If this is a sensible approach.

2. If I copy the complete information that needs to be copied.

(Apologies for the mess of the commits. I'm in the process of learning Git.)