### PR TITLE
TSLRepository also tracks pointers to the human readable TSLs

### DIFF
--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/TSLParserResult.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/TSLParserResult.java
@@ -34,6 +34,7 @@ public class TSLParserResult {
 	private Date issueDate;
 	private Date nextUpdateDate;
 	private List<TSLPointer> pointers;
+	private List<TSLPointer> humanReadableTSLPointers;
 	private List<TSLServiceProvider> serviceProviders;
 	private List<String> distributionPoints;
 
@@ -75,6 +76,14 @@ public class TSLParserResult {
 
 	public void setPointers(List<TSLPointer> pointers) {
 		this.pointers = pointers;
+	}
+
+	public List<TSLPointer> getHumanReadableTSLPointers() {
+		return humanReadableTSLPointers;
+	}
+
+	public void setHumanReadableTSLPointers(List<TSLPointer> humanReadableTSLPointers) {
+		this.humanReadableTSLPointers = humanReadableTSLPointers;
 	}
 
 	public List<TSLServiceProvider> getServiceProviders() {

--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLParser.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLParser.java
@@ -104,6 +104,8 @@ public class TSLParser implements Callable<TSLParserResult> {
 	private static final String ENGLISH_LANGUAGE = "en";
 
 	private static final String TSL_MIME_TYPE = "application/vnd.etsi.tsl+xml";
+	
+	private static final String HUMAN_READABLE_TSL_MIME_TYPE = "application/pdf";
 
 	private static final JAXBContext jaxbContext;
 
@@ -142,6 +144,7 @@ public class TSLParser implements Callable<TSLParserResult> {
 		tslModel.setNextUpdateDate(getNextUpdate(tsl));
 		tslModel.setDistributionPoints(getDistributionPoints(tsl));
 		tslModel.setPointers(getMachineProcessableTSLPointers(tsl));
+		tslModel.setHumanReadableTSLPointers(getHumanReadableTSLPointers(tsl));
 		tslModel.setServiceProviders(getServiceProviders(tsl));
 		return tslModel;
 	}
@@ -195,6 +198,19 @@ public class TSLParser implements Callable<TSLParserResult> {
 		if (Utils.isCollectionNotEmpty(tslPointers)) {
 			for (TSLPointer tslPointer : tslPointers) {
 				if (TSL_MIME_TYPE.equals(tslPointer.getMimeType())) {
+					list.add(tslPointer);
+				}
+			}
+		}
+		return list;
+	}
+
+	private List<TSLPointer> getHumanReadableTSLPointers(TrustStatusListType tsl) {
+		List<TSLPointer> list = new ArrayList<TSLPointer>();
+		List<TSLPointer> tslPointers = getTSLPointers(tsl);
+		if (Utils.isCollectionNotEmpty(tslPointers)) {
+			for (TSLPointer tslPointer : tslPointers) {
+				if (HUMAN_READABLE_TSL_MIME_TYPE.equals(tslPointer.getMimeType())) {
 					list.add(tslPointer);
 				}
 			}

--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLRepository.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLRepository.java
@@ -49,6 +49,7 @@ import eu.europa.esig.dss.tsl.ServiceInfoStatus;
 import eu.europa.esig.dss.tsl.TSLConditionsForQualifiers;
 import eu.europa.esig.dss.tsl.TSLLoaderResult;
 import eu.europa.esig.dss.tsl.TSLParserResult;
+import eu.europa.esig.dss.tsl.TSLPointer;
 import eu.europa.esig.dss.tsl.TSLService;
 import eu.europa.esig.dss.tsl.TSLServiceProvider;
 import eu.europa.esig.dss.tsl.TSLServiceStatusAndInformationExtensions;
@@ -79,6 +80,8 @@ public class TSLRepository {
 
 	private Map<String, TSLValidationModel> tsls = new HashMap<String, TSLValidationModel>();
 
+	private Map<String, TSLPointer> humanReadableTsls = Collections.emptyMap();
+
 	private TrustedListsCertificateSource trustedListsCertificateSource;
 
 	public void setCacheDirectoryPath(String cacheDirectoryPath) {
@@ -103,6 +106,10 @@ public class TSLRepository {
 
 	public TSLValidationModel getByCountry(String countryIsoCode) {
 		return tsls.get(countryIsoCode);
+	}
+
+	public TSLPointer getHumanReadableTSLPointerByCountry(String countryIsoCode) {
+		return humanReadableTsls.get(countryIsoCode);
 	}
 
 	public List<TSLValidationModel> getTSLValidationModels() {
@@ -166,6 +173,7 @@ public class TSLRepository {
 		try {
 			Utils.cleanDirectory(new File(cacheDirectoryPath));
 			tsls.clear();
+			humanReadableTsls = Collections.emptyMap();
 		} catch (IOException e) {
 			logger.error("Unable to clean cache directory : " + e.getMessage(), e);
 		}
@@ -235,6 +243,14 @@ public class TSLRepository {
 
 	private void add(String countryCode, TSLValidationModel tsl) {
 		tsls.put(countryCode, tsl);
+	}
+
+	void setHumanReadableTSLPointers(final Iterable<TSLPointer> ptrs) {
+		final Map<String, TSLPointer> map = new HashMap<String, TSLPointer>();
+		for (final TSLPointer ptr : ptrs) {
+			map.put(ptr.getTerritory(), ptr);
+		}
+		humanReadableTsls = map;
 	}
 
 	private String storeOnFileSystem(String countryCode, TSLLoaderResult resultLoader) {

--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLValidationJob.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLValidationJob.java
@@ -156,6 +156,8 @@ public class TSLValidationJob {
 					}
 				}
 
+				repository.setHumanReadableTSLPointers(europeanModel.getParseResult().getHumanReadableTSLPointers());
+
 				storeValidationResults(futureValidationResults);
 			}
 
@@ -204,6 +206,7 @@ public class TSLValidationJob {
 			} catch (Exception e) {
 				logger.error("Unable to validate the LOTL : " + e.getMessage(), e);
 			}
+			repository.setHumanReadableTSLPointers(europeanModel.getParseResult().getHumanReadableTSLPointers());
 		}
 
 		analyzeCountryPointers(parseResult.getPointers());


### PR DESCRIPTION
TSLRepository.getHumanReadableTSLPointerByCountry(), given a country code,
returns the pointer or null if the human readable TSL was not specified in the LOTL.
