### PR TITLE
Support for CVC concatenated signatures

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/DSSSignatureUtils.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/DSSSignatureUtils.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.ASN1StreamParser;
 import org.bouncycastle.util.BigIntegers;
 
 import eu.europa.esig.dss.DSSException;
@@ -50,7 +51,7 @@ public final class DSSSignatureUtils {
 	 * @return
 	 */
 	public static byte[] convertToXmlDSig(final EncryptionAlgorithm algorithm, byte[] signatureValue) {
-		if (EncryptionAlgorithm.ECDSA == algorithm) {
+		if (EncryptionAlgorithm.ECDSA == algorithm && isAsn1Encoded(signatureValue)) {
 			return convertECDSAASN1toXMLDSIG(signatureValue);
 		} else if (EncryptionAlgorithm.DSA == algorithm) {
 			return convertDSAASN1toXMLDSIG(signatureValue);
@@ -143,6 +144,21 @@ public final class DSSSignatureUtils {
 			Utils.closeQuietly(is);
 		}
 		return buffer.toByteArray();
+	}
+
+	/**
+	 * Checks if the signature is ASN.1 encoded.
+	 *
+	 * @param signatureValue signature value to check.
+	 * @return if the signature is ASN.1 encoded.
+     */
+	private static boolean isAsn1Encoded(byte[] signatureValue) {
+		try {
+			new ASN1StreamParser(signatureValue).readObject();
+			return true;
+		} catch (IOException e) {
+			return false;
+		}
 	}
 
 }

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/encoding/EncodingXMLTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/encoding/EncodingXMLTest.java
@@ -1,5 +1,7 @@
 package eu.europa.esig.dss.xades.encoding;
 
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.security.KeyPair;
@@ -121,4 +123,11 @@ public class EncodingXMLTest {
 		assertTrue(s2.verify(asn1xmlsec));
 	}
 
+	@Test
+	public void testECDSA_CVC_ConcatenatedSignature() throws Exception {
+		String cvcSignatureInHex = "2B9099C9885DDB5BFDA2E9634905B9A63E7E3A6EC87BDC0A89014716B23F00B0AD787FC8D0DCF28F007E7DEC097F30DA892BE2AC61D90997DCDF05740E4D5B0C";
+		byte[] signatureValue = DatatypeConverter.parseHexBinary(cvcSignatureInHex);
+		byte[] xmlDSigValue = DSSSignatureUtils.convertToXmlDSig(EncryptionAlgorithm.ECDSA, signatureValue);
+		assertThat(signatureValue, equalTo(xmlDSigValue));
+	}
 }


### PR DESCRIPTION
This change adds support to CVC concatenated signatures (in addition to ASN.1 encoded signatures).

Because CVC does not follow a structure like ASN.1, then I couldn't find a way to determine if a signature is definitely CVC or not. CVC signature bytes are simply concatenated. It is possible to check if the signature is ASN.1 encoded.

The fix origins from https://esig-dss.atlassian.net/browse/DSS-801

Estonian Mobile ID ECDSA signatures are encoded in CVC.

Regards