### PR TITLE
Fixed skipping TSL validation when LOTL has changed but validation is turned off

### DIFF
--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLValidationJob.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/service/TSLValidationJob.java
@@ -269,7 +269,7 @@ public class TSLValidationJob {
 					futureParseResults.add(executorService.submit(new TSLParser(fis)));
 				}
 
-				if (checkTSLSignatures && ((countryModel.getValidationResult() == null)) || newLotl) {
+				if (checkTSLSignatures && (countryModel.getValidationResult() == null || newLotl)) {
 					TSLValidator tslValidator = new TSLValidator(new File(countryModel.getFilepath()), loaderResult.getCountryCode(), dssKeyStore,
 							getPotentialSigners(pointers, loaderResult.getCountryCode()));
 					futureValidationResults.add(executorService.submit(tslValidator));


### PR DESCRIPTION
This change fixes a small bug that was introduced in DSS-883 (revalidating TSLs).

The problem is that when TSL signature check is turned off (checkTSLSignatures=false), then it still validates TSL, but sometimes we don't want to validate TSL (in some test cases).

This is fixed in the branch 4.7.x

Regards