### PR TITLE
Multilingual info from TL is extracted into model based on a settable LanguagePreference

### DIFF
--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/util/LanguagePreference.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/util/LanguagePreference.java
@@ -1,0 +1,85 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ *
+ * This file is part of the "DSS - Digital Signature Services" project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.util;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * A language preference can select a "best" variant of a datum from a list
+ * based on language.
+ * 
+ * @author jdvorak
+ *
+ */
+public class LanguagePreference {
+
+	private final String[] prefLangCodes;
+
+	/**
+	 * A new language preference (languages from left to right).
+	 * 
+	 * @param langCodes
+	 *            the code of the most preferred language, of the second most
+	 *            preferred one, etc.
+	 */
+	public LanguagePreference(final String... langCodes) {
+		this.prefLangCodes = langCodes;
+	}
+
+	/**
+	 * Choose the preferred item from the given list of items based on language.
+	 * The item with the first preferred language is selected. If that does not
+	 * exist then the item with the second preferred language, and so on. If no
+	 * item matches a preferred language, the first item from the list is
+	 * returned.
+	 * 
+	 * @param items
+	 *            list of items; the items must not be null and must support a
+	 *            <code>getLang()</code> method that returns String
+	 * @return the item that matches the preference best; null if the input list
+	 *         is null or empty
+	 * @throws IllegalArgumentException
+	 *             when there is trouble getting the language of the item
+	 */
+	public <T> T getPreferredOrFirst(final List<T> items) {
+		if (items != null && !items.isEmpty()) {
+			for (final String prefLangCode : prefLangCodes) {
+				for (final T item : items) {
+					final Class<?> clazz = item.getClass();
+					try {
+						final Method method = clazz.getMethod("getLang");
+						final String itemLangCode = (String) method.invoke(item);
+						if (prefLangCode.equals(itemLangCode)) {
+							return item;
+						}
+					} catch (final Exception e) {
+						throw new IllegalArgumentException("Trouble invoking the getLang() method on " + item, e);
+					}
+				}
+			}
+			return items.get(0);
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/dss-tsl-validation/src/test/java/eu/europa/esig/dss/tsl/service/TSLParserTest.java
+++ b/dss-tsl-validation/src/test/java/eu/europa/esig/dss/tsl/service/TSLParserTest.java
@@ -21,14 +21,17 @@ import eu.europa.esig.dss.tsl.TSLPointer;
 import eu.europa.esig.dss.tsl.TSLService;
 import eu.europa.esig.dss.tsl.TSLServiceProvider;
 import eu.europa.esig.dss.tsl.TSLServiceStatusAndInformationExtensions;
+import eu.europa.esig.dss.util.LanguagePreference;
 import eu.europa.esig.dss.utils.Utils;
 import eu.europa.esig.dss.x509.CertificateToken;
 
 public class TSLParserTest {
 
+	protected final LanguagePreference langPref = new LanguagePreference( "en" );
+	
 	@Test
 	public void parseLOTL() throws Exception {
-		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/LOTL.xml")));
+		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/LOTL.xml")), langPref);
 		TSLParserResult model = parser.call();
 		assertNotNull(model);
 		assertNotNull(model.getNextUpdateDate());
@@ -49,7 +52,7 @@ public class TSLParserTest {
 	@Test
 	public void countCertificatesLT() throws Exception {
 		int oldResult = 35;
-		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/621C7723265CA33AAD0607B3C612B313872E7514.xml")));
+		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/621C7723265CA33AAD0607B3C612B313872E7514.xml")), langPref);
 		TSLParserResult model = parser.call();
 
 		Set<CertificateToken> certs = new HashSet<CertificateToken>();
@@ -66,7 +69,7 @@ public class TSLParserTest {
 	@Test
 	public void countCertificatesDE() throws Exception {
 		int oldResult = 413;
-		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/59F95095730A1809A027655246D6524959B191A8.xml")));
+		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/59F95095730A1809A027655246D6524959B191A8.xml")), langPref);
 		TSLParserResult model = parser.call();
 
 		Set<CertificateToken> certs = new HashSet<CertificateToken>();
@@ -83,7 +86,7 @@ public class TSLParserTest {
 	@Test
 	public void serviceQualificationEE() throws Exception {
 		// ***************************** OLD VERSION OF TL
-		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/0A191C3E18CAB7B783E690D3E4431C354A068FF0.xml")));
+		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/0A191C3E18CAB7B783E690D3E4431C354A068FF0.xml")), langPref);
 		TSLParserResult model = parser.call();
 
 		List<TSLServiceProvider> serviceProviders = model.getServiceProviders();
@@ -104,7 +107,7 @@ public class TSLParserTest {
 		CertificateToken certificate = DSSUtils.loadCertificateFromBase64EncodedString(
 				"MIID3DCCAsSgAwIBAgIER/idhzANBgkqhkiG9w0BAQUFADBbMQswCQYDVQQGEwJFRTEiMCAGA1UEChMZQVMgU2VydGlmaXRzZWVyaW1pc2tlc2t1czEPMA0GA1UECxMGRVNURUlEMRcwFQYDVQQDEw5FU1RFSUQtU0sgMjAwNzAeFw0wODA0MDYwOTUzMDlaFw0xMjAzMDUyMjAwMDBaMIGWMQswCQYDVQQGEwJFRTEPMA0GA1UEChMGRVNURUlEMRowGAYDVQQLExFkaWdpdGFsIHNpZ25hdHVyZTEiMCAGA1UEAxMZU0lOSVZFRSxWRUlLTywzNjcwNjAyMDIxMDEQMA4GA1UEBBMHU0lOSVZFRTEOMAwGA1UEKhMFVkVJS08xFDASBgNVBAUTCzM2NzA2MDIwMjEwMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCGRN42R9e6VEHMCyvacuubjtm1+5Kk92WgIgtWA8hY8DW2iNvQJ3jOF5XlVIyIDTwl2JVKxWKhXX+8+yNFPpqAK43IINcmMfznw/KcR7jACGNuTrivA9HrvRiqDzTg5E1rktjho6OkDkdV3dgOLB2wyhVm2anNpICfrUq8c09HPwIDMMP5o4HvMIHsMA4GA1UdDwEB/wQEAwIGQDA8BgNVHR8ENTAzMDGgL6AthitodHRwOi8vd3d3LnNrLmVlL2NybHMvZXN0ZWlkL2VzdGVpZDIwMDcuY3JsMFEGA1UdIARKMEgwRgYLKwYBBAHOHwEBAQEwNzASBggrBgEFBQcCAjAGGgRub25lMCEGCCsGAQUFBwIBFhVodHRwOi8vd3d3LnNrLmVlL2Nwcy8wHwYDVR0jBBgwFoAUSAbevoyHV5WAeGP6nCMrK6A6GHUwHQYDVR0OBBYEFJAJUyDrH3rdxTStU+LDa6aHdE8dMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQEFBQADggEBAA5qjfeuTdOoEtatiA9hpjDHzyqN1PROcaPrABXGqpLxcHbLVr7xmovILAjxS9fJAw28u9ZE3asRNa9xgQNTeX23mMlojJAYVbYCeIeJ6jtsRiCo34wgvO3CtVfO3+C1T8Du5XLCHa6SoT8SpCApW+Crwe+6eCZDmv2NKTjhn1wCCNO2e8HuSt+pTUNBTUB+rkvF4KO9VnuzRzT7zN7AUdW4OFF3bI+9+VmW3t9vq1zDOxNTdBkCM3zm5TRa8ZtyAPL48bW19JAcYzQLjPGORwoIRNSXdVTqX+cDiw2wbmb2IhPdxRqN9uPwU1x/ltZZ3W5GzJ1t8JeQN7PuGM0OHqE=");
 
-		parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/0A191C3E18CAB7B783E690D3E4431C354A068FF0-2.xml")));
+		parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/0A191C3E18CAB7B783E690D3E4431C354A068FF0-2.xml")), langPref);
 		model = parser.call();
 
 		serviceProviders = model.getServiceProviders();
@@ -126,7 +129,7 @@ public class TSLParserTest {
 
 	@Test
 	public void getAdditionnalServiceInfo() throws Exception {
-		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/tsl-be-v5.xml")));
+		TSLParser parser = new TSLParser(new FileInputStream(new File("src/test/resources/tsls/tsl-be-v5.xml")), langPref);
 		TSLParserResult model = parser.call();
 
 		List<TSLServiceProvider> serviceProviders = model.getServiceProviders();

--- a/dss-tsl-validation/src/test/java/eu/europa/esig/dss/tsl/service/TSLSParserTest.java
+++ b/dss-tsl-validation/src/test/java/eu/europa/esig/dss/tsl/service/TSLSParserTest.java
@@ -19,6 +19,7 @@ import eu.europa.esig.dss.tsl.TSLPointer;
 import eu.europa.esig.dss.tsl.TSLService;
 import eu.europa.esig.dss.tsl.TSLServiceProvider;
 import eu.europa.esig.dss.tsl.TSLServiceStatusAndInformationExtensions;
+import eu.europa.esig.dss.util.LanguagePreference;
 import eu.europa.esig.dss.util.TimeDependentValues;
 import eu.europa.esig.dss.utils.Utils;
 
@@ -52,9 +53,11 @@ public class TSLSParserTest {
 		this.fileToTest = fileToTest;
 	}
 
+	protected final LanguagePreference langPref = new LanguagePreference( "en" );
+	
 	@Test
 	public void parseTSL() throws Exception {
-		TSLParser parser = new TSLParser(new FileInputStream(fileToTest));
+		TSLParser parser = new TSLParser(new FileInputStream(fileToTest), langPref);
 		TSLParserResult result = parser.call();
 		assertNotNull(result);
 		assertNotNull(result.getNextUpdateDate());

--- a/dss-tsl-validation/src/test/java/eu/europa/esig/dss/util/LanguagePreferenceTest.java
+++ b/dss-tsl-validation/src/test/java/eu/europa/esig/dss/util/LanguagePreferenceTest.java
@@ -1,0 +1,102 @@
+package eu.europa.esig.dss.util;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class LanguagePreferenceTest {
+
+	protected final MockLanguageDependentString s1Eng = new MockLanguageDependentString("a string", "en");
+	protected final MockLanguageDependentString s2Eng = new MockLanguageDependentString("another string", "en");
+	protected final MockLanguageDependentString s3Eng = new MockLanguageDependentString("yet another string", "en");
+
+	protected final MockLanguageDependentString s1Ger = new MockLanguageDependentString("eine Zeichenkette", "de");
+	protected final MockLanguageDependentString s2Ger = new MockLanguageDependentString("eine andere Zeichenkette",
+			"de");
+	protected final MockLanguageDependentString s3Ger = new MockLanguageDependentString("eine noch andere Zeichenkette",
+			"de");
+
+	@Test
+	public void testEmptyPreference() {
+		final LanguagePreference p = new LanguagePreference();
+		assertNull(p.getPreferredOrFirst(null));
+		assertNull(p.getPreferredOrFirst(Collections.emptyList()));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Ger)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s2Eng)));
+	}
+
+	@Test
+	public void testEnglishPreference() {
+		final LanguagePreference p = new LanguagePreference("en");
+		assertNull(p.getPreferredOrFirst(null));
+		assertNull(p.getPreferredOrFirst(Collections.emptyList()));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Ger)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Eng)));
+		assertSame(s3Eng, p.getPreferredOrFirst(Arrays.asList(s2Ger, s3Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s1Ger)));
+	}
+
+	@Test
+	public void testGermanPreference() {
+		final LanguagePreference p = new LanguagePreference("de");
+		assertNull(p.getPreferredOrFirst(null));
+		assertNull(p.getPreferredOrFirst(Collections.emptyList()));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Ger)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s3Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s1Ger)));
+	}
+
+	@Test
+	public void testEnglishAndGermanPreference() {
+		final LanguagePreference p = new LanguagePreference("en", "de");
+		assertNull(p.getPreferredOrFirst(null));
+		assertNull(p.getPreferredOrFirst(Collections.emptyList()));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Ger)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Eng)));
+		assertSame(s3Eng, p.getPreferredOrFirst(Arrays.asList(s2Ger, s3Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s1Ger)));
+	}
+
+	@Test
+	public void testGermanAndEnglishPreference() {
+		final LanguagePreference p = new LanguagePreference("de", "en");
+		assertNull(p.getPreferredOrFirst(null));
+		assertNull(p.getPreferredOrFirst(Collections.emptyList()));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Ger)));
+		assertSame(s1Eng, p.getPreferredOrFirst(Arrays.asList(s1Eng, s2Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s3Eng)));
+		assertSame(s2Ger, p.getPreferredOrFirst(Arrays.asList(s2Ger, s1Ger)));
+	}
+
+}
+
+class MockLanguageDependentString {
+
+	private final String value;
+	private final String lang;
+
+	public MockLanguageDependentString(String value, String lang) {
+		super();
+		this.value = value;
+		this.lang = lang;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public String getLang() {
+		return lang;
+	}
+
+}


### PR DESCRIPTION
The names of services, the names and postal addresses of TSPs are multilingual in the Trusted Lists. However, the present model only has space for simple strings. Applications aiming at a specific national environment may prefer info in a specific language(s), of course defaulting to English.

This PR introduces a settable LanguagePreferrence strategy into TSLParser. This strategy does the selection based on the language of the information.
