### PR TITLE
Implement visible multi-line PDF signatures

### DIFF
--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageTextParameters.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageTextParameters.java
@@ -46,6 +46,11 @@ public class SignatureImageTextParameters {
 	private SignerPosition signerNamePosition = SignerPosition.LEFT;
 
 	/**
+	 * This variable defines how signer name is aligned horizontally
+	 */
+	private TextAlignment signerNameHorizontalAlignment = TextAlignment.HORIZONTAL_LEFT;
+
+	/**
 	 * This variable defines the text to sign
 	 */
 	private String text;
@@ -74,6 +79,24 @@ public class SignatureImageTextParameters {
 
 	public void setSignerNamePosition(SignerPosition signerNamePosition) {
 		this.signerNamePosition = signerNamePosition;
+	}
+
+	/**
+	 * Gets signer name (signature text) horizontal alignment.
+	 *
+	 * @return signature text horizontal alignment
+	 */
+	public TextAlignment getSignerNameHorizontalAlignment() {
+		return signerNameHorizontalAlignment;
+	}
+
+	/**
+	 * Sets signer name (signature text) horizontal alignment.
+	 *
+	 * @param alignment     horizontal values of {@link TextAlignment}
+	 */
+	public void setSignerNameHorizontalAlignment(TextAlignment alignment) {
+		this.signerNameHorizontalAlignment = alignment;
 	}
 
 	public Font getFont() {

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/TextAlignment.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/TextAlignment.java
@@ -1,0 +1,11 @@
+package eu.europa.esig.dss.pades;
+
+
+/**
+ * Enum to define how to align multi-line signer name on the image.
+ */
+public enum TextAlignment {
+	HORIZONTAL_LEFT,
+	HORIZONTAL_CENTER,
+	HORIZONTAL_RIGHT
+}

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/signature/visible/ImageUtils.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/signature/visible/ImageUtils.java
@@ -46,7 +46,7 @@ public class ImageUtils {
 		if ((textParamaters != null) && Utils.isStringNotEmpty(textParamaters.getText())) {
 
 			BufferedImage buffImg = ImageTextWriter.createTextImage(textParamaters.getText(), textParamaters.getFont(), textParamaters.getTextColor(),
-					textParamaters.getBackgroundColor(), DPI);
+					textParamaters.getBackgroundColor(), DPI, textParamaters.getSignerNameHorizontalAlignment());
 
 			if (imageParameters.getImage() != null) {
 				switch (textParamaters.getSignerNamePosition()) {


### PR DESCRIPTION
**Add support for multi-line signer name w/ horizontal alignment flag**

This pull request implements multi-line text rendering for visual PDF signatures. Original signature image parameters interface is extended with two functionalities:

- Support for using '\n' in signature image text as a line-break character
- Support for setting horizontal alignment of the multi-line text (left, right, center)

Backwards compatibility is maintained - please see attached sample PDF files for comparison of the original functionality (original.pdf) and multi-line enabled functionality (multiline.pdf).

[original.pdf](https://github.com/esig/dss/files/562478/original.pdf)
[multiline.pdf](https://github.com/esig/dss/files/562479/multiline.pdf)