### PR TITLE
Do not add empty unsigned attributes to timestamp token

### DIFF
--- a/dss-cades/src/main/java/eu/europa/esig/dss/cades/signature/CAdESSignatureExtension.java
+++ b/dss-cades/src/main/java/eu/europa/esig/dss/cades/signature/CAdESSignatureExtension.java
@@ -293,6 +293,10 @@ abstract class CAdESSignatureExtension implements SignatureExtension<CAdESSignat
 					final ASN1Encodable objectAt = attributeToAdd.getAttrValues().getObjectAt(0);
 					unsignedAttributes = unsignedAttributes.add(attrType, objectAt);
 				}
+				// Unsigned attributes cannot be empty (RFC 5652 5.3)
+				if (unsignedAttributes.size() == 0) {
+					unsignedAttributes = null;
+				}
 				final SignerInformation newSignerInformation = SignerInformation.replaceUnsignedAttributes(signerInformation, unsignedAttributes);
 				final List<SignerInformation> signerInformationList = new ArrayList<SignerInformation>();
 				signerInformationList.add(newSignerInformation);


### PR DESCRIPTION
This change fixes an issue that has been observed when trying to validate PAdES signatures with timestamp tokens generated with SD-DSS in [ETSI conformance checker plugtests](http://signatures-conformance-checker.etsi.org).

Due to an empty set of unsigned attributes, the validator complains: 
https://www.dropbox.com/s/8ytbejijoks0lyu/Screenshot%202016-11-15%2010.44.23.png?dl=0

The error message expects there to be one or more values in the attribute map so this fix simply sets the unsigned attributes to `null` if empty and it validates successfully.

This seems similar to what was fixed in https://github.com/esig/dss/commit/4878d5fc33eb49e1a09d572b46034572a60e5cec

Hope this helps.