### PR TITLE
Fix visible signature pdfa

### DIFF
--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/signature/visible/ImageTextWriter.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/signature/visible/ImageTextWriter.java
@@ -78,7 +78,7 @@ public final class ImageTextWriter {
                                                  final int height, SignatureImageTextParameters.SignerTextHorizontalAlignment horizontalAlignment) {
         String[] lines = text.split("\n");
 
-        BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         Graphics2D g = img.createGraphics();
         g.setFont(font);
         FontMetrics fm = g.getFontMetrics(font);


### PR DESCRIPTION
Hello,
I changed BufferedImage type in method:
ImageTextWriter.createTextImage
From BufferedImage.TYPE_INT_ARGB to BufferedImage.TYPE_INT_RGB

It's because after applying a visible signature on a PDF/A doc, the PDF/A  doc then not confrom with the conformance.