### PR TITLE
Fixes certs-only parsing by instead of returning one of the found cer…

### DIFF
--- a/dss-spi/src/test/java/eu/europa/esig/dss/DSSUtilsTest.java
+++ b/dss-spi/src/test/java/eu/europa/esig/dss/DSSUtilsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -51,9 +52,20 @@ public class DSSUtilsTest {
 	}
 
 	@Test
+	public void testDontSkipCertificatesWhenMultipleAreFoundInP7c() throws IOException {
+		try {
+			DSSUtils.loadCertificate(new FileInputStream("src/test/resources/certchain.p7c"));
+			fail("Should not load single certificate (first?)");
+		} catch(DSSException dssEx){
+			assertEquals(dssEx.getMessage(), "Could not parse certificate");
+		}
+	}
+
+	@Test
 	public void testLoadP7cPEM() throws DSSException, IOException {
 		Collection<CertificateToken> certs = DSSUtils.loadCertificateFromP7c(new FileInputStream("src/test/resources/certchain.p7c"));
 		assertTrue(Utils.isCollectionNotEmpty(certs));
+		assertTrue(certs.size() > 1);
 	}
 
 	@Test


### PR DESCRIPTION
If a certs-only stream is parsed, throw if it contains multiple certificates. The caller should call the loadP7c method and if necessary filter out.