### PR TITLE
Enable the use of different filters and subfilters for PAdES signatures

### DIFF
--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/PAdESSignatureParameters.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/PAdESSignatureParameters.java
@@ -11,6 +11,8 @@ public class PAdESSignatureParameters extends CAdESSignatureParameters {
 	private String contactInfo;
 	private String location;
 	private String signatureFieldId;
+	private String filter = "Adobe.PPKLite";
+	private String subFilter = "ETSI.CAdES.detached";
 
 	private int signatureSize = 9472; // default value in pdfbox
 
@@ -102,5 +104,21 @@ public class PAdESSignatureParameters extends CAdESSignatureParameters {
 	 */
 	public void setSignatureSize(int signatureSize) {
 		this.signatureSize = signatureSize;
+	}
+
+	public String getFilter() {
+		return filter;
+	}
+
+	public void setFilter(String filter) {
+		this.filter = filter;
+	}
+
+	public String getSubFilter() {
+		return subFilter;
+	}
+
+	public void setSubFilter(String subFilter) {
+		this.subFilter = subFilter;
 	}
 }

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -87,7 +87,7 @@ import java.util.Set;
 class PdfBoxSignatureService implements PDFSignatureService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PdfBoxSignatureService.class);
-
+	
 	@Override
 	public byte[] digest(final InputStream toSignDocument, final PAdESSignatureParameters parameters, final DigestAlgorithm digestAlgorithm)
 			throws DSSException {
@@ -213,9 +213,8 @@ class PdfBoxSignatureService implements PDFSignatureService {
 			signature.setName(shortName);
 		}
 
-		signature.setFilter(PDSignature.FILTER_ADOBE_PPKLITE); // default filter
-		// sub-filter for basic and PAdES Part 2 signatures
-		signature.setSubFilter(getSubFilter());
+		signature.setFilter(COSName.getPDFName(parameters.getFilter()));
+		signature.setSubFilter(getSubFilter() == null? COSName.getPDFName(parameters.getSubFilter()): getSubFilter());
 
 		if (COSName.SIG.equals(getType())) {
 			if (Utils.isStringNotEmpty(parameters.getContactInfo())) {
@@ -277,7 +276,7 @@ class PdfBoxSignatureService implements PDFSignatureService {
 	}
 
 	protected COSName getSubFilter() {
-		return PDSignature.SUBFILTER_ETSI_CADES_DETACHED;
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Main changes:
- adding extension point to enable different filter/subfilter combinations
- a fix on certificate generation (adding digital signature KeyUsage)
- adding a utility method to use MSCapi to test signatures