### PR TITLE
Added check for bridged certificates to avoid infinite loop

### DIFF
--- a/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
@@ -371,6 +371,10 @@ public class CertificateToken extends Token {
 
 			final PublicKey publicKey = issuerToken.getCertificate().getPublicKey();
 			x509Certificate.verify(publicKey);
+			CertificateToken issuerTokenIssuer = issuerToken.getIssuerToken();
+			if ((issuerTokenIssuer != null) && (issuerTokenIssuer.equals(this))) {
+				throw new DSSException("Bridged certificates are not supported yet");
+			}
 			signatureValid = true;
 			if (!isSelfSigned()) {
 				this.issuerToken = issuerToken;


### PR DESCRIPTION
When there's a signature using a certificate that has a bridged certificate path it never exits the `SignatureValidationContext.getIssuerFromAIA()` method.

The idea is to end the signatures processing since it is not yet supported.

FYI: @davydsantos