### PR TITLE
TSL condition getters

### DIFF
--- a/dss-spi/src/main/java/eu/europa/esig/dss/tsl/CertSubjectDNAttributeCondition.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/tsl/CertSubjectDNAttributeCondition.java
@@ -1,6 +1,8 @@
 package eu.europa.esig.dss.tsl;
 
+import java.util.Collections;
 import java.util.List;
+import static java.util.Collections.unmodifiableList;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -32,6 +34,18 @@ public class CertSubjectDNAttributeCondition extends Condition {
 	public CertSubjectDNAttributeCondition(List<String> oids) {
 		this.subjectAttributeOids = oids;
 	}
+
+    /**
+     * Returns the list of DN attribute OIDs to be checked
+     * against the certificate’s subject DN.
+     * 
+     * @return an unmodifiable list, possibly empty; never {@code null}
+     */
+    public final List<String> getAttributeOids() {
+        return subjectAttributeOids == null ?
+            Collections.<String> emptyList() :
+            unmodifiableList(subjectAttributeOids);
+    }
 
 	@Override
 	public boolean check(CertificateToken certificateToken) {

--- a/dss-spi/src/main/java/eu/europa/esig/dss/tsl/CompositeCondition.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/tsl/CompositeCondition.java
@@ -22,6 +22,7 @@ package eu.europa.esig.dss.tsl;
 
 import java.util.ArrayList;
 import java.util.List;
+import static java.util.Collections.unmodifiableList;
 
 import eu.europa.esig.dss.DSSException;
 import eu.europa.esig.dss.x509.CertificateToken;
@@ -57,6 +58,15 @@ public class CompositeCondition extends Condition {
 	public CompositeCondition(final MatchingCriteriaIndicator matchingCriteriaIndicator) {
 		this.matchingCriteriaIndicator = matchingCriteriaIndicator;
 	}
+
+    /**
+     * Returns the list of child conditions.
+     * 
+     * @return an unmodifiable list, possibly empty; never {@code null}
+     */
+    public final List<Condition> getChildren() {
+        return unmodifiableList(children);
+    }
 
 	/**
 	 * This method adds a child condition. This allows to handle embedded conditions.

--- a/dss-spi/src/main/java/eu/europa/esig/dss/tsl/ExtendedKeyUsageCondition.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/tsl/ExtendedKeyUsageCondition.java
@@ -1,6 +1,8 @@
 package eu.europa.esig.dss.tsl;
 
+import java.util.Collections;
 import java.util.List;
+import static java.util.Collections.unmodifiableList;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 
@@ -33,6 +35,18 @@ public class ExtendedKeyUsageCondition extends Condition {
 		this.extendedKeyUsageOids = oids;
 	}
 
+    /**
+     * Returns the list key purpose IDs to be be checked against the
+     * certificate’s extended key usage extension.
+     * 
+     * @return an unmodifiable list, possibly empty; never {@code null}
+     */
+    public final List<String> getKeyPurposeIds() {
+        return extendedKeyUsageOids == null ?
+            Collections.<String> emptyList() :
+            unmodifiableList(extendedKeyUsageOids);
+    }
+    
 	@Override
 	public boolean check(CertificateToken certificateToken) {
 		if (Utils.isCollectionNotEmpty(extendedKeyUsageOids)) {

--- a/dss-spi/src/main/java/eu/europa/esig/dss/tsl/KeyUsageCondition.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/tsl/KeyUsageCondition.java
@@ -20,6 +20,8 @@
  */
 package eu.europa.esig.dss.tsl;
 
+import static java.util.Objects.requireNonNull;
+
 import eu.europa.esig.dss.x509.CertificateToken;
 
 /**
@@ -33,29 +35,48 @@ public class KeyUsageCondition extends Condition {
 	private final boolean value;
 
 	/**
-	 * The default constructor for KeyUsageCondition.
+	 * Constructs a new KeyUsageCondition.
 	 *
 	 * @param bit
 	 *            the key usage
 	 * @param value
-	 *            true if the key usage is required
+	 *            the required value of the key usage bit
 	 */
 	public KeyUsageCondition(final KeyUsageBit bit, final boolean value) {
+        requireNonNull(bit, "key usage");
 		this.bit = bit;
 		this.value = value;
 	}
 
 	/**
-	 * The default constructor for KeyUsageCondition.
+	 * Constructs a new KeyUsageCondition.
 	 *
 	 * @param usage
 	 *            the key usage
 	 * @param value
-	 *            true if the key usage is required
+	 *            the required value of the key usage bit
 	 */
 	public KeyUsageCondition(final String usage, final boolean value) {
 		this(KeyUsageBit.valueOf(usage), value);
 	}
+
+    /**
+     * Returns the key usage to be checked.
+     * 
+     * @return never {@code null}
+     */
+    public final KeyUsageBit getBit() {
+        return bit;
+    }
+    
+    /**
+     * Returns the required bit value of the key usage to be checked.
+     * 
+     * @return the required bit value of the key usage to be checked
+     */
+    public final boolean getValue() {
+        return value;
+    }
 
 	@Override
 	public boolean check(final CertificateToken certificateToken) {

--- a/dss-spi/src/main/java/eu/europa/esig/dss/tsl/PolicyIdCondition.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/tsl/PolicyIdCondition.java
@@ -52,6 +52,15 @@ public class PolicyIdCondition extends Condition {
 		this.policyOid = policyId;
 	}
 
+    /**
+     *  Returns the policy OID.
+     * 
+     *  @return never {@code null}
+     */
+    public final String getPolicyOid() {
+        return policyOid;
+    }
+
 	@Override
 	public boolean check(final CertificateToken certificateToken) {
 		if (certificateToken == null) {


### PR DESCRIPTION
This adds getter methods to the TSL condition subtypes, cf. [DSS-1436](https://ec.europa.eu/cefdigital/tracker/browse/DSS-1436).
I also added a null check to the constructor of KeyUsageCondition to guarantee a non-null KeyUsageBit.
