### PR TITLE
resolved exception when validating 'ASIC' signatures from web services

### DIFF
--- a/dss-spi/src/main/java/eu/europa/esig/dss/DigestDocument.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/DigestDocument.java
@@ -20,6 +20,9 @@
  */
 package eu.europa.esig.dss;
 
+import eu.europa.esig.dss.utils.Utils;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -28,6 +31,8 @@ import java.io.InputStream;
  * of the digest associated to the file can be done externally.
  */
 public class DigestDocument extends CommonDocument {
+
+	private DigestAlgorithm digestAlgorithm;
 
 	/**
 	 * Creates DigestDocument.
@@ -47,6 +52,7 @@ public class DigestDocument extends CommonDocument {
 	 */
 	public void addDigest(final DigestAlgorithm digestAlgorithm, final String base64EncodeDigest) {
 		base64EncodeDigestMap.put(digestAlgorithm, base64EncodeDigest);
+		this.digestAlgorithm = digestAlgorithm;
 	}
 
 	@Override
@@ -60,7 +66,8 @@ public class DigestDocument extends CommonDocument {
 
 	@Override
 	public InputStream openStream() throws DSSException {
-		throw new DSSException("Digest document");
+		String base64EncodeDigest = base64EncodeDigestMap.get(digestAlgorithm);
+		return new ByteArrayInputStream(Utils.fromBase64(base64EncodeDigest));
 	}
 
 	@Override


### PR DESCRIPTION
We were getting this exception when attempting to validate ASIC signatures using SOAP service:

`ERROR | http-nio-8080-exec-6 | eu.europa.esig.dss.validation.SignedDocumentValidator   | Cannot instanciate class 'eu.europa.esig.dss.cades.validation.CMSDocumentValidator' : Digest document
eu.europa.esig.dss.DSSException: Digest document
        at eu.europa.esig.dss.DigestDocument.openStream(DigestDocument.java:63)
        at eu.europa.esig.dss.DSSUtils.readFirstByte(DSSUtils.java:802)
        at eu.europa.esig.dss.cades.validation.CMSDocumentValidator.isSupported(CMSDocumentValidator.java:86)
        at eu.europa.esig.dss.validation.SignedDocumentValidator.fromDocument(SignedDocumentValidator.java:154)
        at eu.europa.esig.dss.validation.RemoteDocumentValidationService.validateDocument(RemoteDocumentValidationService.java:27)
        at eu.europa.esig.dss.validation.SoapDocumentValidationServiceImpl.validateSignature(SoapDocumentValidationServiceImpl.java:17)`