### PR TITLE
fix to let cache expire also for POST requests

### DIFF
--- a/dss-service/src/main/java/eu/europa/esig/dss/client/http/commons/FileCacheDataLoader.java
+++ b/dss-service/src/main/java/eu/europa/esig/dss/client/http/commons/FileCacheDataLoader.java
@@ -251,7 +251,9 @@ public class FileCacheDataLoader implements DataLoader {
 		final String digestHexEncoded = DSSUtils.toHex(digest);
 		final String cacheFileName = fileName + "." + digestHexEncoded;
 		final File file = getCacheFile(cacheFileName);
-		if (file.exists()) {
+		final boolean fileExists = file.exists();
+		final boolean isCacheExpired = isCacheExpired(file);
+		if (fileExists && !isCacheExpired) {
 
 			LOG.debug("Cached file was used");
 			final byte[] byteArray = DSSUtils.toByteArray(file);


### PR DESCRIPTION
isExpired check was missing for the FileCacheDataLoader post-request.