### PR TITLE
add raw Revocation Values to diagnostic data (optionally)

### DIFF
--- a/dss-diagnostic-jaxb/src/main/java/eu/europa/esig/dss/jaxb/diagnostic/XmlRevocation.java
+++ b/dss-diagnostic-jaxb/src/main/java/eu/europa/esig/dss/jaxb/diagnostic/XmlRevocation.java
@@ -50,6 +50,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *         &lt;element name="BasicSignature" type="{http://dss.esig.europa.eu/validation/diagnostic}BasicSignature" minOccurs="0"/&gt;
  *         &lt;element name="SigningCertificate" type="{http://dss.esig.europa.eu/validation/diagnostic}SigningCertificate" minOccurs="0"/&gt;
  *         &lt;element name="CertificateChain" type="{http://dss.esig.europa.eu/validation/diagnostic}CertificateChain" minOccurs="0"/&gt;
+ *         &lt;element name="Base64Encoded" type="{http://www.w3.org/2001/XMLSchema}base64Binary" minOccurs="0"/&gt;
  *       &lt;/sequence&gt;
  *       &lt;attribute name="Id" use="required" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
  *     &lt;/restriction&gt;
@@ -78,7 +79,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
     "digestAlgoAndValues",
     "basicSignature",
     "signingCertificate",
-    "certificateChain"
+    "certificateChain",
+    "base64Encoded"
 })
 public class XmlRevocation implements Serializable
 {
@@ -134,6 +136,8 @@ public class XmlRevocation implements Serializable
     @XmlElementWrapper(name = "CertificateChain")
     @XmlElement(name = "ChainItem", namespace = "http://dss.esig.europa.eu/validation/diagnostic")
     protected List<XmlChainItem> certificateChain;
+    @XmlElement(name = "Base64Encoded")
+    protected byte[] base64Encoded;
     @XmlAttribute(name = "Id", required = true)
     protected String id;
 
@@ -513,6 +517,28 @@ public class XmlRevocation implements Serializable
         this.signingCertificate = value;
     }
 
+    /**
+     * Gets the value of the base64Encoded property.
+     * 
+     * @return
+     *     possible object is
+     *     byte[]
+     */
+    public byte[] getBase64Encoded() {
+        return base64Encoded;
+    }
+
+    /**
+     * Sets the value of the base64Encoded property.
+     * 
+     * @param value
+     *     allowed object is
+     *     byte[]
+     */
+    public void setBase64Encoded(byte[] value) {
+        this.base64Encoded = value;
+    }
+    
     /**
      * Gets the value of the id property.
      * 

--- a/dss-diagnostic-jaxb/src/main/resources/xsd/DiagnosticData.xsd
+++ b/dss-diagnostic-jaxb/src/main/resources/xsd/DiagnosticData.xsd
@@ -453,6 +453,8 @@
 			<xs:element name="BasicSignature" type="BasicSignature" minOccurs="0" /> <!-- Can be null in case of no SUCCESSFUL response of OCSP -->
 			<xs:element name="SigningCertificate" type="SigningCertificate" minOccurs="0" />
 			<xs:element name="CertificateChain" type="CertificateChain" minOccurs="0" />
+			
+			<xs:element name="Base64Encoded" type="xs:base64Binary" minOccurs="0" />
 		</xs:sequence>
 		<xs:attribute name="Id" type="xs:string" use="required" />
 	</xs:complexType>

--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/CertificateVerifier.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/CertificateVerifier.java
@@ -173,5 +173,13 @@ public interface CertificateVerifier {
 	 * during the validation process.
 	 */
 	CertificatePool createValidationPool();
-
+	
+	/**
+	 * This method allows to change the behavior by including raw revocation data.
+	 * 
+	 * @param include
+	 * 					true if raw revocation data should be included (default: false)
+	 */
+	void setIncludeCertificateRevocationValues(boolean include);
+	boolean includeCertificateRevocationValues();
 }

--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/CommonCertificateVerifier.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/CommonCertificateVerifier.java
@@ -86,11 +86,17 @@ public class CommonCertificateVerifier implements CertificateVerifier {
 	private ListOCSPSource signatureOCSPSource;
 
 	/**
-	 * This variable set the bahavior to follow in case of missing revocation data
+	 * This variable set the behavior to follow in case of missing revocation data
 	 * (augmentation process). True : throw an exception / False : add a warning
 	 * message. Default : true
 	 */
 	private boolean exceptionOnMissingRevocationData = true;
+	
+	/**
+	 * This variable set the behavior to include raw revocation data into the diagnostic report.
+	 * (default: false) 
+	 */
+	private boolean includeRawRevocationData = false;
 
 	/**
 	 * The default constructor. The {@code DataLoader} is created to allow the
@@ -230,6 +236,16 @@ public class CommonCertificateVerifier implements CertificateVerifier {
 			validationPool.importCerts(adjunctCertSource);
 		}
 		return validationPool;
+	}
+
+	@Override
+	public void setIncludeCertificateRevocationValues(boolean include) {
+		this.includeRawRevocationData = include;
+	}
+
+	@Override
+	public boolean includeCertificateRevocationValues() {
+		return this.includeRawRevocationData;
 	}
 
 }

--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
@@ -403,6 +403,8 @@ public class DiagnosticDataBuilder {
 
 		xmlRevocation.setSigningCertificate(getXmlSigningCertificate(revocationToken.getPublicKeyOfTheSigner()));
 		xmlRevocation.setCertificateChain(getXmlForCertificateChain(revocationToken.getPublicKeyOfTheSigner()));
+		
+		xmlRevocation.setBase64Encoded( revocationToken.getEncoded() );
 
 		return xmlRevocation;
 	}


### PR DESCRIPTION
Hi Pierrick,

In the following our suggestion to include the Revocation-data optionally in the DiagnosticData (Base64 encoded).

I hope this is ok to include in 5.4?

Regards