### PR TITLE
Bug fix: certificate wrapper isRevoked implementation

### DIFF
--- a/dss-reports/src/main/java/eu/europa/esig/dss/validation/reports/wrapper/CertificateWrapper.java
+++ b/dss-reports/src/main/java/eu/europa/esig/dss/validation/reports/wrapper/CertificateWrapper.java
@@ -154,7 +154,7 @@ public class CertificateWrapper extends AbstractTokenProxy {
 
 	public boolean isRevoked() {
 		RevocationWrapper latestRevocationData = getLatestRevocationData();
-		return latestRevocationData != null && latestRevocationData.isStatus() && latestRevocationData.getRevocationDate() != null;
+		return latestRevocationData != null && !latestRevocationData.isStatus() && latestRevocationData.getRevocationDate() != null;
 	}
 
 	public boolean isValidCertificate() {


### PR DESCRIPTION
Certificate wrapper incorrectly returns isRevoked value.
(**status** field needs to be interpreted as: true if valid, false if revoked/onhold)