### PR TITLE
Get certificate validation pool from CertificateVerifier.

### DIFF
--- a/dss-cades/src/main/java/eu/europa/esig/dss/cades/signature/CAdESLevelBaselineLT.java
+++ b/dss-cades/src/main/java/eu/europa/esig/dss/cades/signature/CAdESLevelBaselineLT.java
@@ -72,7 +72,7 @@ public class CAdESLevelBaselineLT extends CAdESSignatureExtension {
 			throws DSSException {
 
 		// add a LT level or replace an existing LT level
-		CAdESSignature cadesSignature = new CAdESSignature(cmsSignedData, signerInformation);
+		CAdESSignature cadesSignature = new CAdESSignature(cmsSignedData, signerInformation, certificateVerifier.createValidationPool());
 		cadesSignature.setDetachedContents(parameters.getDetachedContents());
 		if (!cadesSignature.isDataForSignatureLevelPresent(SignatureLevel.CAdES_BASELINE_T)) {
 			signerInformation = cadesProfileT.extendCMSSignature(cmsSignedData, signerInformation, parameters);
@@ -83,7 +83,7 @@ public class CAdESLevelBaselineLT extends CAdESSignatureExtension {
 
 	@Override
 	protected CMSSignedData postExtendCMSSignedData(CMSSignedData cmsSignedData, SignerInformation signerInformation, CAdESSignatureParameters parameters) {
-		CAdESSignature cadesSignature = new CAdESSignature(cmsSignedData, signerInformation);
+		CAdESSignature cadesSignature = new CAdESSignature(cmsSignedData, signerInformation, certificateVerifier.createValidationPool());
 		cadesSignature.setDetachedContents(parameters.getDetachedContents());
 		final ValidationContext validationContext = cadesSignature.getSignatureValidationContext(certificateVerifier);
 

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESLevelBaselineT.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESLevelBaselineT.java
@@ -60,7 +60,9 @@ import eu.europa.esig.dss.xades.DSSXMLUtils;
 import eu.europa.esig.dss.xades.ProfileParameters;
 import eu.europa.esig.dss.xades.ProfileParameters.Operation;
 import eu.europa.esig.dss.xades.XAdESSignatureParameters;
+import eu.europa.esig.dss.xades.XPathQueryHolder;
 import eu.europa.esig.dss.xades.validation.XAdESSignature;
+import java.util.Arrays;
 
 /**
  * -T profile of XAdES signature
@@ -129,7 +131,7 @@ public class XAdESLevelBaselineT extends ExtensionBuilder implements SignatureEx
 
 				continue;
 			}
-			xadesSignature = new XAdESSignature(currentSignatureDom);
+			xadesSignature = new XAdESSignature(currentSignatureDom, Arrays.asList(new XPathQueryHolder()), certificateVerifier.createValidationPool());
 			xadesSignature.setDetachedContents(params.getDetachedContents());
 			extendSignatureTag();
 		}


### PR DESCRIPTION
Fixes [DSS-1581](https://ec.europa.eu/cefdigital/tracker/projects/DSS/issues/DSS-1581).
This change unifies the behaviour during validation.
XAdES and CAdES signatures behave differently from PAdeES signatures.
All signature types now use the validation pool from the CertificateVerifier instead of creating a new, empty instance.