### PR TITLE
Feature: Signature placement in XAdES according to OASIS DSS standard

### DIFF
--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/XAdESSignatureParameters.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/XAdESSignatureParameters.java
@@ -32,6 +32,18 @@ import eu.europa.esig.dss.xades.reference.Base64Transform;
 import eu.europa.esig.dss.xades.reference.DSSReference;
 
 public class XAdESSignatureParameters extends AbstractSignatureParameters {
+    
+	public enum XPathElementPlacement {
+
+		/**
+		 * Insert signature after the element referenced by XPath
+		 */
+		XPathAfter,
+		/**
+		 * Insert signature as first child of element referenced by XPath
+		 */
+		XPathFirstChildOf,
+	}
 
 	private ProfileParameters context;
 
@@ -96,6 +108,8 @@ public class XAdESSignatureParameters extends AbstractSignatureParameters {
 	private String signedPropertiesCanonicalizationMethod;
 
 	private String xPathLocationString;
+
+	private XPathElementPlacement xPathElementPlacement;
 	
 	/**
 	 * If true, prints each signature's tag to a new line with a relevant indent
@@ -220,6 +234,21 @@ public class XAdESSignatureParameters extends AbstractSignatureParameters {
 	public void setXPathLocationString(String xPathLocationString) {
 		this.xPathLocationString = xPathLocationString;
 	}
+
+	public XPathElementPlacement getXPathElementPlacement() {
+                return xPathElementPlacement;
+        }
+
+	/**
+	 * Defines the area where the signature will be added (XAdES Enveloped) 
+	 * in relation to the element referenced by the XPath
+	 *
+	 * @param xPathElementPlacement
+	 *            the xpath location of the signature
+	 */
+        public void setXPathElementPlacement(XPathElementPlacement xPathElementPlacement) {
+                this.xPathElementPlacement = xPathElementPlacement;
+        }
 
 	public Document getRootDocument() {
 		return rootDocument;

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/EnvelopedSignatureBuilder.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/EnvelopedSignatureBuilder.java
@@ -84,6 +84,37 @@ class EnvelopedSignatureBuilder extends XAdESSignatureBuilder {
 		}
 		return documentDom.getDocumentElement();
 	}
+	
+	@Override
+	protected void incorporateSignatureDom(Node parentNodeOfSignature) {
+	    if (params.getXPathElementPlacement() == null || Utils.isStringEmpty(params.getXPathLocationString())) {
+		parentNodeOfSignature.appendChild(signatureDom);
+		return;
+	    }
+
+	    switch (params.getXPathElementPlacement()) {
+		    case XPathAfter:
+			    // root element referenced by XPath
+			    if (parentNodeOfSignature.isEqualNode(documentDom.getDocumentElement())) { 
+				    // append signature at end of document
+				    parentNodeOfSignature.appendChild(signatureDom);
+				    
+			    } else {
+				    // insert signature before next sibling or as last child
+				    // if no sibling exists
+				    Node parent = parentNodeOfSignature.getParentNode();
+				    parent.insertBefore(signatureDom, parentNodeOfSignature.getNextSibling());
+			    }
+
+			    break;
+		    case XPathFirstChildOf:
+			    parentNodeOfSignature.insertBefore(signatureDom, parentNodeOfSignature.getFirstChild());
+			    break;
+		    default:
+			    parentNodeOfSignature.appendChild(signatureDom);
+			    break;
+	    }
+	}
 
 	@Override
 	protected DSSReference createReference(DSSDocument document, int referenceIndex) {

--- a/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESSignatureBuilder.java
+++ b/dss-xades/src/main/java/eu/europa/esig/dss/xades/signature/XAdESSignatureBuilder.java
@@ -309,11 +309,15 @@ public abstract class XAdESSignatureBuilder extends XAdESBuilder implements Sign
 		signatureDom.setAttribute(ID, deterministicId);
 
 		final Node parentNodeOfSignature = getParentNodeOfSignature();
-		parentNodeOfSignature.appendChild(signatureDom);
+		incorporateSignatureDom(parentNodeOfSignature);
 	}
 
 	protected Node getParentNodeOfSignature() {
 		return documentDom;
+	}
+
+	protected void incorporateSignatureDom(Node parentNodeOfSignature) {
+		parentNodeOfSignature.appendChild(signatureDom);
 	}
 
 	/**

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementAfterRootNodeTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementAfterRootNodeTest.java
@@ -1,0 +1,98 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.signature;
+
+import eu.europa.esig.dss.DomUtils;
+import java.io.File;
+import java.util.Date;
+
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignaturePackaging;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
+import eu.europa.esig.dss.model.InMemoryDocument;
+import eu.europa.esig.dss.signature.DocumentSignatureService;
+import eu.europa.esig.dss.xades.XAdESSignatureParameters;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class XAdESLevelBEnvelopedWithXPathPlacementAfterRootNodeTest extends AbstractXAdESTestSignature {
+
+	private DocumentSignatureService<XAdESSignatureParameters> service;
+	private XAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+	private final String XPATH = "/*";
+
+	@Before
+	public void init() throws Exception {
+		documentToSign = new FileDocument(new File("src/test/resources/sample.xml"));
+
+		signatureParameters = new XAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignaturePackaging(SignaturePackaging.ENVELOPED);
+		signatureParameters.setSignatureLevel(SignatureLevel.XAdES_BASELINE_B);
+		// Will add the signature as last child of the root node
+		signatureParameters.setXPathLocationString(XPATH);
+		signatureParameters.setXPathElementPlacement(XAdESSignatureParameters.XPathElementPlacement.XPathAfter);
+
+		service = new XAdESService(getCompleteCertificateVerifier());
+
+	}
+
+	@Override
+	protected void onDocumentSigned(byte[] byteArray) {
+		super.onDocumentSigned(byteArray);
+		Document dom = DomUtils.buildDOM(byteArray);
+		Element referencedElement = DomUtils.getElement(dom.getDocumentElement(), XPATH);
+		assertTrue(referencedElement.getLastChild()!= null);
+		assertTrue("ds:Signature".equals(referencedElement.getLastChild().getNodeName()));
+	}
+
+	@Override
+	protected DocumentSignatureService<XAdESSignatureParameters> getService() {
+		return service;
+	}
+
+	@Override
+	protected XAdESSignatureParameters getSignatureParameters() {
+		return signatureParameters;
+	}
+
+	@Override
+	protected DSSDocument getDocumentToSign() {
+		return documentToSign;
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementAfterTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementAfterTest.java
@@ -1,0 +1,94 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.signature;
+
+import eu.europa.esig.dss.DomUtils;
+import java.io.File;
+import java.util.Date;
+
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignaturePackaging;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
+import eu.europa.esig.dss.signature.DocumentSignatureService;
+import eu.europa.esig.dss.xades.XAdESSignatureParameters;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class XAdESLevelBEnvelopedWithXPathPlacementAfterTest extends AbstractXAdESTestSignature {
+
+	private DocumentSignatureService<XAdESSignatureParameters> service;
+	private XAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+	private final String XPATH = "//*[local-name() = 'tr']";
+
+	@Before
+	public void init() throws Exception {
+		documentToSign = new FileDocument(new File("src/test/resources/sample.xml"));
+
+		signatureParameters = new XAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignaturePackaging(SignaturePackaging.ENVELOPED);
+		signatureParameters.setSignatureLevel(SignatureLevel.XAdES_BASELINE_B);
+		// Will add the signature after the tr tag
+		signatureParameters.setXPathLocationString(XPATH);
+		signatureParameters.setXPathElementPlacement(XAdESSignatureParameters.XPathElementPlacement.XPathAfter);
+
+		service = new XAdESService(getCompleteCertificateVerifier());
+
+	}
+
+	@Override
+	protected void onDocumentSigned(byte[] byteArray) {
+		super.onDocumentSigned(byteArray);
+		Document dom = DomUtils.buildDOM(byteArray);
+		Element referencedElement = DomUtils.getElement(dom.getDocumentElement(), XPATH);
+		assertTrue(referencedElement.getNextSibling() != null);
+		assertTrue("ds:Signature".equals(referencedElement.getNextSibling().getNodeName()));
+	}
+
+	@Override
+	protected DocumentSignatureService<XAdESSignatureParameters> getService() {
+		return service;
+	}
+
+	@Override
+	protected XAdESSignatureParameters getSignatureParameters() {
+		return signatureParameters;
+	}
+
+	@Override
+	protected DSSDocument getDocumentToSign() {
+		return documentToSign;
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementFirstChildTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementFirstChildTest.java
@@ -1,0 +1,94 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.signature;
+
+import eu.europa.esig.dss.DomUtils;
+import java.io.File;
+import java.util.Date;
+
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignaturePackaging;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
+import eu.europa.esig.dss.signature.DocumentSignatureService;
+import eu.europa.esig.dss.xades.XAdESSignatureParameters;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class XAdESLevelBEnvelopedWithXPathPlacementFirstChildTest extends AbstractXAdESTestSignature {
+
+	private DocumentSignatureService<XAdESSignatureParameters> service;
+	private XAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+	private final String XPATH = "//*[local-name() = 'tr']";
+
+	@Before
+	public void init() throws Exception {
+		documentToSign = new FileDocument(new File("src/test/resources/sample.xml"));
+
+		signatureParameters = new XAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignaturePackaging(SignaturePackaging.ENVELOPED);
+		signatureParameters.setSignatureLevel(SignatureLevel.XAdES_BASELINE_B);
+		// Will add the signature as first child of the tr tag
+		signatureParameters.setXPathLocationString(XPATH);
+		signatureParameters.setXPathElementPlacement(XAdESSignatureParameters.XPathElementPlacement.XPathFirstChildOf);
+
+		service = new XAdESService(getCompleteCertificateVerifier());
+
+	}
+
+	@Override
+	protected void onDocumentSigned(byte[] byteArray) {
+		super.onDocumentSigned(byteArray);
+		Document dom = DomUtils.buildDOM(byteArray);
+		Element referencedElement = DomUtils.getElement(dom.getDocumentElement(), XPATH);
+		assertTrue(referencedElement.getFirstChild() != null);
+		assertTrue("ds:Signature".equals(referencedElement.getFirstChild().getNodeName()));
+	}
+
+	@Override
+	protected DocumentSignatureService<XAdESSignatureParameters> getService() {
+		return service;
+	}
+
+	@Override
+	protected XAdESSignatureParameters getSignatureParameters() {
+		return signatureParameters;
+	}
+
+	@Override
+	protected DSSDocument getDocumentToSign() {
+		return documentToSign;
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}

--- a/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementNoneTest.java
+++ b/dss-xades/src/test/java/eu/europa/esig/dss/xades/signature/XAdESLevelBEnvelopedWithXPathPlacementNoneTest.java
@@ -1,0 +1,93 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.signature;
+
+import eu.europa.esig.dss.DomUtils;
+import java.io.File;
+import java.util.Date;
+
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignaturePackaging;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
+import eu.europa.esig.dss.signature.DocumentSignatureService;
+import eu.europa.esig.dss.xades.XAdESSignatureParameters;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class XAdESLevelBEnvelopedWithXPathPlacementNoneTest extends AbstractXAdESTestSignature {
+
+	private DocumentSignatureService<XAdESSignatureParameters> service;
+	private XAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+	private final String XPATH = "//*[local-name() = 'tr']";
+
+	@Before
+	public void init() throws Exception {
+		documentToSign = new FileDocument(new File("src/test/resources/sample.xml"));
+
+		signatureParameters = new XAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignaturePackaging(SignaturePackaging.ENVELOPED);
+		signatureParameters.setSignatureLevel(SignatureLevel.XAdES_BASELINE_B);
+		// Will add the signature as last child of the tr tag
+		signatureParameters.setXPathLocationString(XPATH);
+
+		service = new XAdESService(getCompleteCertificateVerifier());
+
+	}
+
+	@Override
+	protected void onDocumentSigned(byte[] byteArray) {
+		super.onDocumentSigned(byteArray);
+		Document dom = DomUtils.buildDOM(byteArray);
+		Element referencedElement = DomUtils.getElement(dom.getDocumentElement(), XPATH);
+		assertTrue(referencedElement.getLastChild()!= null);
+		assertTrue("ds:Signature".equals(referencedElement.getLastChild().getNodeName()));
+	}
+
+	@Override
+	protected DocumentSignatureService<XAdESSignatureParameters> getService() {
+		return service;
+	}
+
+	@Override
+	protected XAdESSignatureParameters getSignatureParameters() {
+		return signatureParameters;
+	}
+
+	@Override
+	protected DSSDocument getDocumentToSign() {
+		return documentToSign;
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}


### PR DESCRIPTION
In the [OASIS Digital Signature Service Protocol](https://docs.oasis-open.org/dss-x/dss-core/v2.0/dss-core-v2.0.html) there is a component called SignaturePlacement (chapter 4.4.18). It is used to request an enveloped XAdES signature for a document with the option to add an XPath to specify where the signature element is to appear within the signed document. So far this is supported by DSS. However, SignaturePlacement further distinguishes between two cases, namely "XPathAfter" and "XPathFirstChildOf". Depending on which is used the signed document should look different for the same XPath. For the first case, the signature element should appear as next sibling of the element referenced by the XPath, whereas for the second it should be inserted as its first child. Currently DSS inserts the signature DOM as last child by default. This pull request implements the necessary changes to support the two cases above depending on a user provided parameter and falls back to the current DSS implementation if no specific XPathElementPlacement is requested. Tests for all three options have also been added.