### PR TITLE
Change System.out.println to slf4j debug logging

### DIFF
--- a/validation-policy/src/main/java/eu/europa/esig/dss/validation/reports/AbstractReports.java
+++ b/validation-policy/src/main/java/eu/europa/esig/dss/validation/reports/AbstractReports.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 
 import javax.xml.bind.JAXBException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import eu.europa.esig.dss.detailedreport.DetailedReport;
@@ -39,6 +41,8 @@ import eu.europa.esig.dss.diagnostic.jaxb.XmlDiagnosticData;
  */
 public abstract class AbstractReports {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractReports.class);
+	
 	protected boolean validateXml = false;
 
 	private final DiagnosticData diagnosticDataWrapper;
@@ -146,13 +150,15 @@ public abstract class AbstractReports {
 	 * For debug purpose.
 	 */
 	public void print() {
-		System.out.println("----------------Diagnostic data-----------------");
-		System.out.println(getXmlDiagnosticData());
-		System.out.println("----------------Validation report---------------");
-		System.out.println(getXmlDetailedReport());
-		System.out.println("----------------Simple report-------------------");
-		System.out.println(getXmlSimpleReport());
-		System.out.println("------------------------------------------------");
+		if(LOGGER.isDebugEnabled()) {
+			LOGGER.debug("----------------Diagnostic data-----------------");
+			LOGGER.debug(getXmlDiagnosticData());
+			LOGGER.debug("----------------Validation report---------------");
+			LOGGER.debug(getXmlDetailedReport());
+			LOGGER.debug("----------------Simple report-------------------");
+			LOGGER.debug(getXmlSimpleReport());
+			LOGGER.debug("------------------------------------------------");
+		}
 	}
 
 }

--- a/validation-policy/src/main/java/eu/europa/esig/dss/validation/reports/Reports.java
+++ b/validation-policy/src/main/java/eu/europa/esig/dss/validation/reports/Reports.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 
 import javax.xml.bind.JAXBException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import eu.europa.esig.dss.detailedreport.jaxb.XmlDetailedReport;
@@ -40,6 +42,8 @@ import eu.europa.esig.validationreport.jaxb.ValidationReportType;
  */
 public class Reports extends AbstractReports {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(Reports.class);
+	
 	private final SimpleReport simpleReportWrapper;
 
 	private String xmlSimpleReport;
@@ -134,19 +138,21 @@ public class Reports extends AbstractReports {
 
 	@Override
 	public void print() {
-		System.out.println("----------------Diagnostic data-----------------");
-		System.out.println(getXmlDiagnosticData());
-		System.out.println("----------------Validation report---------------");
-		System.out.println(getXmlDetailedReport());
-		System.out.println("----------------Simple report-------------------");
-		System.out.println(getXmlSimpleReport());
-		System.out.println("----------------ETSI validation report-------------------");
-		if (etsiValidationReport != null) {
-			System.out.println(getXmlValidationReport());
-		} else {
-			System.out.println("---------- ETSI validation report is disabled -----------");
+		if(LOGGER.isDebugEnabled()) {
+			LOGGER.debug("----------------Diagnostic data-----------------");
+			LOGGER.debug(getXmlDiagnosticData());
+			LOGGER.debug("----------------Validation report---------------");
+			LOGGER.debug(getXmlDetailedReport());
+			LOGGER.debug("----------------Simple report-------------------");
+			LOGGER.debug(getXmlSimpleReport());
+			LOGGER.debug("----------------ETSI validation report-------------------");
+			if (etsiValidationReport != null) {
+				LOGGER.debug(getXmlValidationReport());
+			} else {
+				LOGGER.debug("---------- ETSI validation report is disabled -----------");
+			}
+			LOGGER.debug("---------------------------------------------------------");
 		}
-		System.out.println("---------------------------------------------------------");
 	}
 
 }


### PR DESCRIPTION
We was surprised after validation, because at our application stdout file was big instead of zero size and it was full with diagnose data xml.

The reason was the Reports#print function was write everything into the System.out instead of into the Logger.