### PR TITLE
Fixing the link to CEF Digital repository in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please, use the new JIRA for project is on https://ec.europa.eu/cefdigital/track
 
 The release is published on CEF Digital repository : 
 
-https://ec.europa.eu/cefdigital/artifact/#welcome
+https://ec.europa.eu/cefdigital/artifact/#browse/welcome
 
 <pre>
 &lt;repository&gt;


### PR DESCRIPTION
Fixing in the link on the develop branch.