### PR TITLE
Update maven-javadoc-plugin version from 3.1.1 to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 		            <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Motivations:
* Keep the technical stack up-to-date

Modifications:
* Update maven-javadoc-plugin version from 3.1.1 to 3.2.0

Results:
* No functional impact