### PR TITLE
make SignatureImageParameters serializable and add test to check

### DIFF
--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/AbstractDSSFont.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/AbstractDSSFont.java
@@ -21,8 +21,9 @@
 package eu.europa.esig.dss.pades;
 
 import java.awt.Font;
+import java.io.Serializable;
 
-public abstract class AbstractDSSFont implements DSSFont {
+public abstract class AbstractDSSFont implements DSSFont, Serializable {
 	
 	protected static final float DEFAULT_TEXT_SIZE = 12f;
 	

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageParameters.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageParameters.java
@@ -24,12 +24,13 @@ import java.awt.Color;
 
 import eu.europa.esig.dss.model.DSSDocument;
 import eu.europa.esig.dss.pdf.visible.CommonDrawerUtils;
+import java.io.Serializable;
 
 /**
  * Parameters for a visible signature creation
  *
  */
-public class SignatureImageParameters {
+public class SignatureImageParameters implements Serializable {
 
 	public static final int DEFAULT_PAGE = 1;
 

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageTextParameters.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageTextParameters.java
@@ -21,12 +21,13 @@
 package eu.europa.esig.dss.pades;
 
 import java.awt.Color;
+import java.io.Serializable;
 
 /**
  * This class allows to custom text generation in the PAdES visible signature
  *
  */
-public class SignatureImageTextParameters {
+public class SignatureImageTextParameters implements Serializable {
 
 	private static final Color DEFAULT_BACKGROUND_COLOR = Color.WHITE;
 	private static final float DEFAULT_PADDING = 5f;

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/visible/ImageUtils.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/visible/ImageUtils.java
@@ -149,7 +149,7 @@ public class ImageUtils {
 
 	private static boolean isImageWithContentType(DSSDocument image, MimeType expectedContentType) {
 		if (image.getMimeType() != null) {
-			return expectedContentType == image.getMimeType();
+			return image.getMimeType().equals(expectedContentType);
 		} else if (image.getName() != null) {
 			String contentType = null;
 			try {

--- a/dss-pades/src/test/java/eu/europa/esig/dss/pades/PAdESSignatureParametersSerializationTest.java
+++ b/dss-pades/src/test/java/eu/europa/esig/dss/pades/PAdESSignatureParametersSerializationTest.java
@@ -72,9 +72,14 @@ public class PAdESSignatureParametersSerializationTest extends PKIFactoryAccess 
 
 	@Test
 	public void testSerialization() throws IOException, ClassNotFoundException {
+		
 		SignatureImageParameters imageParameters = new SignatureImageParameters();
 		imageParameters.setImage(new InMemoryDocument(getClass().getResourceAsStream("/signature-image.png"), "signature-image.png", MimeType.PNG));
+		SignatureImageTextParameters imageTextParameters = new SignatureImageTextParameters();
+		imageTextParameters.setText("test");
+		imageParameters.setTextParameters(imageTextParameters);
 		signatureParameters.setImageParameters(imageParameters);
+
 
 		PAdESTimestampParameters timestampParameters = new PAdESTimestampParameters();
 		signatureParameters.setArchiveTimestampParameters(timestampParameters);

--- a/dss-pades/src/test/java/eu/europa/esig/dss/pades/PAdESSignatureParametersSerializationTest.java
+++ b/dss-pades/src/test/java/eu/europa/esig/dss/pades/PAdESSignatureParametersSerializationTest.java
@@ -1,0 +1,97 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.pades;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.europa.esig.dss.diagnostic.DiagnosticData;
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.InMemoryDocument;
+import eu.europa.esig.dss.model.MimeType;
+import eu.europa.esig.dss.model.SignatureValue;
+import eu.europa.esig.dss.model.ToBeSigned;
+import eu.europa.esig.dss.pades.PAdESSignatureParameters;
+import eu.europa.esig.dss.pades.PAdESSignatureParameters;
+import eu.europa.esig.dss.pades.PAdESTimestampParameters;
+import eu.europa.esig.dss.pades.SignatureImageParameters;
+import eu.europa.esig.dss.pades.SignatureImageParameters;
+import eu.europa.esig.dss.pades.SignatureImageTextParameters;
+import eu.europa.esig.dss.pades.signature.PAdESService;
+import eu.europa.esig.dss.signature.DocumentSignatureService;
+import eu.europa.esig.dss.test.signature.PKIFactoryAccess;
+import eu.europa.esig.dss.validation.SignedDocumentValidator;
+import eu.europa.esig.dss.validation.reports.Reports;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Assertions;
+
+
+public class PAdESSignatureParametersSerializationTest extends PKIFactoryAccess {
+
+	private PAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+
+	@BeforeEach
+	public void init() throws Exception {
+		documentToSign = new InMemoryDocument(getClass().getResourceAsStream("/doc.pdf"));
+
+		signatureParameters = new PAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
+		signatureParameters.setSignatureFieldId("Signature1");
+	}
+
+	@Test
+	public void testSerialization() throws IOException, ClassNotFoundException {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(new InMemoryDocument(getClass().getResourceAsStream("/signature-image.png"), "signature-image.png", MimeType.PNG));
+		signatureParameters.setImageParameters(imageParameters);
+
+		PAdESTimestampParameters timestampParameters = new PAdESTimestampParameters();
+		signatureParameters.setArchiveTimestampParameters(timestampParameters);
+		signatureParameters.setContentTimestampParameters(timestampParameters);
+		
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(signatureParameters);
+
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		PAdESSignatureParameters desSignatureParameters = (PAdESSignatureParameters)ois.readObject();
+
+		Assertions.assertEquals(signatureParameters, desSignatureParameters);
+	}
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}


### PR DESCRIPTION
We need to serialize PAdESSignatureParameters, but this is blocked by SignatureImageParameters not implementing Serializable. This has been changed and a test for serialization has been added. 