### PR TITLE
Log fix in getSigningCertificateAnnouncementUrl

### DIFF
--- a/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/dto/builder/ParsingCacheDTOBuilder.java
+++ b/dss-tsl-validation/src/main/java/eu/europa/esig/dss/tsl/dto/builder/ParsingCacheDTOBuilder.java
@@ -134,7 +134,7 @@ public class ParsingCacheDTOBuilder extends AbstractCacheDTOBuilder<AbstractPars
 		if (result instanceof LOTLParsingResult) {
 			return ((LOTLParsingResult) getResult()).getSigningCertificateAnnouncementURL();
 		}
-		LOG.debug("Cannot extract Pivot URLs for the entry. The parsed file is not a LOTL. Return empty list.");
+		LOG.debug("Cannot extract Signing Certificate Announcement URL for the entry. The parsed file is not a LOTL. Return null.");
 		return null;
 	}
 


### PR DESCRIPTION
Fixed the `log.debug` line in `getSigningCertificateAnnouncementUrl()` so that it is accurate to the method. Looked copy/pasted from `getPivotUrls()` and not customized afterwards.