### PR TITLE
Allow custom entries in signature dictionary

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -231,7 +231,7 @@ public class PdfBoxSignatureService extends AbstractPDFSignatureService {
 		}
 	}
 
-	private PDSignature createSignatureDictionary(final PAdESCommonParameters parameters, PDDocument pdDocument) {
+	protected PDSignature createSignatureDictionary(final PAdESCommonParameters parameters, PDDocument pdDocument) {
 
 		PDSignature signature;
 		if (!isDocumentTimestampLayer() && Utils.isStringNotEmpty(parameters.getFieldId())) {


### PR DESCRIPTION
Thanks for this excellent software.

Sometimes is important add custom entries, or any relevant infornation as PDPropBuild, in the signature dictionary, but the only way to access PDSignature whith less internvention is getting the return of the createSignatureDictionary private method. Changing it to protected permit us overwrite and add more entries in parent returned signature.

```
@Override
protected PDSignature createSignatureDictionary(final PAdESCommonParameters parameters, PDDocument pdDocument)
{
    PDSignature signature = super.createSignatureDictionary(parameters, pdDocument);

    // Do something

    return signature;
}
```