### PR TITLE
DSS-2393 Junit tests for eSignature validation test cases

### DIFF
--- a/dss-validation-esig-test/pom.xml
+++ b/dss-validation-esig-test/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>eu.europa.ec.joinup.sd-dss</groupId>
+		<artifactId>sd-dss</artifactId>
+		<version>5.9-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>dss-validation-esig-test</artifactId>
+	<name>DSS Validation tests from eSignature validation test cases</name>
+
+	<dependencies>
+		<!-- Imports junit launcher, jupiter engine and params, dss-service, dss-utils, dss-crl-parser-->
+		<dependency>
+			<groupId>eu.europa.ec.joinup.sd-dss</groupId>
+			<artifactId>dss-test</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>eu.europa.ec.joinup.sd-dss</groupId>
+			<artifactId>dss-tsl-validation</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/dss-validation-esig-test/src/test/java/eu/europa/esig/dss/xades/validation/esig/test/ESigValidationCasesRepository.java
+++ b/dss-validation-esig-test/src/test/java/eu/europa/esig/dss/xades/validation/esig/test/ESigValidationCasesRepository.java
@@ -1,0 +1,466 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.validation.esig.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible for downloading Validation eSig tests, and allows
+ * iterating over tests. Tests with same LOTL config are contiguous in list.
+ * 
+ * See : https://webgate.ec.europa.eu/esig-validation-tests
+ * 
+ * @author Nicolas ROY 
+ */
+public class ESigValidationCasesRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(ESigValidationCasesRepository.class);
+
+	/**
+	 * Actually, LOTL and associated P12 update may be quite chaotic on Test
+	 * Validation website. For example, provided P12 for LOTL-2 and LOTL-3 were
+	 * updated on 2020-09-24, but LOTLs were not updated (and were still signed with
+	 * previous certificate issued on 2020-09-19, even after 24h).
+	 * 
+	 * Therefore, we have a mechanism to take the certificate from the LOTL and make
+	 * it the P12.
+	 * 
+	 * Disabled as the update bug does not seem to reappear (2020-11-16).
+	 */
+	private static final boolean FIX_LOTL_P12 = false;
+
+	/**
+	 * Points to a ZIP, containing a ZIP for each LOTL
+	 */
+	private static final String CASES_DOWNLOAD_URL = "https://webgate.ec.europa.eu/esig-validation-tests/testcase/testFile/all";
+	private static final FileFilter LOTL_URL_FILTER = new FileSuffixFilter("LOTL URL.txt");
+	private static final FileFilter LOTL_P12_FILTER = new FileSuffixFilter(".p12");
+	private static final FileFilter LOTL_P12_PASSWORD_FILTER = new FileSuffixFilter("PASSWORD.txt");
+
+	private static final String TEST_FILE_SUFFIX = "-TEST FILE.xml";
+	private static final String CONCLUSION_FILE_SUFFIX = "-CONCLUSION.txt";
+	private static final FileFilter TEST_FILE_FILTER = new FileSuffixFilter(TEST_FILE_SUFFIX);
+
+	// Folder where cases are downloaded
+	private final String casesFolder = "./target/ValidationCases" + System.currentTimeMillis();
+
+	/**
+	 * The actual list of all Validation tests. Note : tests with same LOTL config
+	 * are contiguous in this list
+	 */
+	private final List<ValidationTest> validationTests = new ArrayList<>();
+
+	/**
+	 * Create the repository by downloading, unzipping and parsing files.
+	 * 
+	 * @throws SAXException
+	 * @throws ParserConfigurationException
+	 * @throws CertificateException
+	 * @throws NoSuchAlgorithmException
+	 * @throws KeyStoreException
+	 */
+	public ESigValidationCasesRepository() throws IOException, ParserConfigurationException, SAXException,
+			KeyStoreException, NoSuchAlgorithmException, CertificateException {
+		new File(casesFolder).mkdir();
+
+		URL url = new URL(CASES_DOWNLOAD_URL);
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+		// Unexpected response ?
+		if (HttpURLConnection.HTTP_OK != connection.getResponseCode()) {
+			fail("Unexpected response while downloading test cases from URL " + CASES_DOWNLOAD_URL + " Response code : "
+					+ connection.getResponseCode() + ". Body : " + getString(connection.getInputStream()));
+		}
+
+		ZipInputStream zis = new ZipInputStream(connection.getInputStream());
+
+		// Unzip the content in CASES_FOLDER
+		ZipEntry entry;
+		while ((entry = zis.getNextEntry()) != null) {
+			File lotlZipDir = new File(casesFolder, entry.getName().replace(".zip", ""));
+			lotlZipDir.mkdir();
+			unzip(zis, lotlZipDir);
+		}
+		zis.close();
+
+		// Parse files
+		List<File> folders = Arrays.asList(new File(casesFolder).listFiles());
+		Collections.sort(folders);
+
+		for (File folder : folders) {
+			parseFolder(folder);
+		}
+	}
+
+	private static void unzip(InputStream inputStream, File targetDir) throws IOException {
+		ZipInputStream zis = new ZipInputStream(inputStream);
+		ZipEntry entry;
+		while ((entry = zis.getNextEntry()) != null) {
+			FileOutputStream fos = new FileOutputStream(new File(targetDir, entry.getName()));
+			transfer(zis, fos);
+			fos.close();
+		}
+	}
+
+	/**
+	 * Test cases related to a single lotl
+	 * 
+	 * @throws IOException
+	 * @throws SAXException
+	 * @throws ParserConfigurationException
+	 * @throws KeyStoreException
+	 * @throws CertificateException
+	 * @throws NoSuchAlgorithmException
+	 */
+	private void parseFolder(File lotlFolder) throws IOException, ParserConfigurationException, SAXException,
+			KeyStoreException, NoSuchAlgorithmException, CertificateException {
+		// First, get the LOTL configuration
+		String lotlUrl = getFileContent(lotlFolder, LOTL_URL_FILTER);
+		File lotlP12 = getFile(lotlFolder, LOTL_P12_FILTER);
+		String lotlP12Password = getFileContent(lotlFolder, LOTL_P12_PASSWORD_FILTER);
+
+		LOTLConfig lotlConfig = new LOTLConfig(lotlUrl, lotlP12, lotlP12Password);
+
+		// Iterate on cases
+		List<File> testFiles = Arrays.asList(lotlFolder.listFiles(TEST_FILE_FILTER));
+		Collections.sort(testFiles);
+
+		for (File testFile : testFiles) {
+			if (testFile.length() == 0) {
+				// Some test files are empty in Validation test cases... Ignore them
+				logger.warn("Test file " + testFile.getName() + " is empty. Ignoring.");
+
+			} else {
+				// Get conclusion filename from test filename
+				String conclusionFileName = testFile.getName().replace(TEST_FILE_SUFFIX, CONCLUSION_FILE_SUFFIX);
+				
+				String expectedConclusion = getFileContent(new File(lotlFolder, conclusionFileName));
+
+				// Add test at the end of list : tests with same LOTL config will be contiguous.
+				validationTests.add(new ValidationTest(testFile, expectedConclusion, lotlConfig));
+			}
+		}
+	}
+
+	/**
+	 * A file suffix filter
+	 * 
+	 * @author nro
+	 */
+	private static class FileSuffixFilter implements FileFilter {
+		private final String suffix;
+
+		public FileSuffixFilter(String suffix) {
+			this.suffix = suffix;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public boolean accept(File pathname) {
+			return pathname.getName().endsWith(suffix);
+		}
+
+		/**
+		 * Useful in case of error, to display the filter config
+		 */
+		@Override
+		public String toString() {
+			return "Filter by suffix = " + suffix;
+		}
+	}
+
+	/**
+	 * Obtain file matching filter in given folder.
+	 * 
+	 * Will fail if no file, or many files match the filter
+	 */
+	private File getFile(File folder, FileFilter filter) {
+		File[] files = folder.listFiles(filter);
+		if (files.length != 1) {
+			fail("In folder " + folder.getAbsolutePath() + ", " + filter.toString() + " returned " + files.length
+					+ " file(s) while 1 was expected");
+		}
+
+		return files[0];
+	}
+
+	/**
+	 * Obtain the content file matching filter in given folder.
+	 * 
+	 * Will fail if no file, or many files match the filter
+	 * 
+	 * @throws IOException
+	 */
+	private String getFileContent(File folder, FileFilter filter) throws IOException {
+		File file = getFile(folder, filter);
+		return getFileContent(file);
+	}
+
+	/**
+	 * Get the content of a file as a string
+	 * 
+	 * @param file
+	 * @return
+	 * @throws IOException
+	 */
+	private String getFileContent(File file) throws IOException {
+		FileInputStream fis = new FileInputStream(file);
+		try {
+			return getString(fis);
+		} finally {
+			fis.close();
+		}
+	}
+
+	public List<ValidationTest> getValidationTests() {
+		return validationTests;
+	}
+
+	/**
+	 * A unit test
+	 * 
+	 * @author nro
+	 *
+	 */
+	public static class ValidationTest {
+		private final File testFile;
+		private final String expectedConclusion;
+		private final LOTLConfig lotlConfig;
+
+		public ValidationTest(File testFile, String expectedConclusion, LOTLConfig lotlConfig) {
+			this.testFile = testFile;
+			this.expectedConclusion = expectedConclusion;
+			this.lotlConfig = lotlConfig;
+		}
+
+		public File getTestFile() {
+			return testFile;
+		}
+
+		public String getExpectedConclusion() {
+			return expectedConclusion;
+		}
+
+		public LOTLConfig getLotlConfig() {
+			return lotlConfig;
+		}
+
+		@Override
+		public String toString() {
+			return "[Validation Test " + this.testFile.getName() + "]";
+		}
+	}
+
+	/**
+	 * LOTL configuration. Implements equal (Two LOTL are equal if they have same
+	 * URL)
+	 * 
+	 * @author nro
+	 *
+	 */
+	public static class LOTLConfig {
+		private final String lotlUrl;
+		private final File lotlP12;
+		private final String lotlP12Password;
+
+		public LOTLConfig(String lotlUrl, File lotlP12, String lotlP12Password)
+				throws IOException, ParserConfigurationException, SAXException, KeyStoreException,
+				NoSuchAlgorithmException, CertificateException {
+			this.lotlUrl = lotlUrl;
+			this.lotlP12 = lotlP12;
+			this.lotlP12Password = lotlP12Password;
+
+			// Fix P12 if we are asked to (c.f. comment on FIX_LOTL_P12)
+			if (FIX_LOTL_P12) {
+				this.fixP12();
+			}
+		}
+
+		public String getLotlUrl() {
+			return lotlUrl;
+		}
+
+		public File getLotlP12() {
+			return lotlP12;
+		}
+
+		public String getLotlP12Password() {
+			return lotlP12Password;
+		}
+
+		/**
+		 * Two LOTL have same hashcode if they have same URL
+		 */
+		@Override
+		public int hashCode() {
+			return this.lotlUrl.hashCode();
+		}
+
+		/**
+		 * Two LOTL are equal if they have same URL
+		 */
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof LOTLConfig)) {
+				return false;
+			}
+			return this.lotlUrl.equals(((LOTLConfig) obj).lotlUrl);
+		}
+
+		@Override
+		public String toString() {
+			return "[LOTL at endpoint " + this.lotlUrl + "]";
+		}
+
+		/**
+		 * Fix the P12 to reflect the actual certificate used to sign LOTL.
+		 * 
+		 * @throws IOException
+		 * @throws ParserConfigurationException
+		 * @throws SAXException
+		 * @throws KeyStoreException
+		 * @throws CertificateException
+		 * @throws NoSuchAlgorithmException
+		 */
+		private void fixP12() throws IOException, ParserConfigurationException, SAXException, KeyStoreException,
+				NoSuchAlgorithmException, CertificateException {
+			// Download LOTL
+			URL url = new URL(this.lotlUrl);
+			HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+			// Unexpected response ?
+			if (HttpURLConnection.HTTP_OK != connection.getResponseCode()) {
+				fail("Unexpected response while downloading LOTL " + this.lotlUrl + " for fixing P12. Response code : "
+						+ connection.getResponseCode() + ". Body : " + getString(connection.getInputStream()));
+			}
+
+			// Extract the certificate used to sign
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder builder = factory.newDocumentBuilder();
+			Document document = builder.parse(connection.getInputStream());
+			Element root = document.getDocumentElement();
+			Element signature = getFirstChild(root, "ds:Signature");
+			Element keyInfo = getFirstChild(signature, "ds:KeyInfo");
+			Element x509Data = getFirstChild(keyInfo, "ds:X509Data");
+			Element x509Certificate = getFirstChild(x509Data, "ds:X509Certificate");
+			String base64 = x509Certificate.getTextContent();
+			byte[] certBytes = Base64.getDecoder().decode(base64);
+			CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+
+			Certificate certificate = certFactory.generateCertificate(new ByteArrayInputStream(certBytes));
+
+			KeyStore keystore = KeyStore.getInstance("PKCS12");
+			// Initialize.
+			keystore.load(null, this.lotlP12Password.toCharArray());
+
+			keystore.setCertificateEntry("fixed-lotl-certif", certificate);
+
+			// Overwrite
+			FileOutputStream fos = new FileOutputStream(this.lotlP12);
+			keystore.store(fos, this.lotlP12Password.toCharArray());
+			fos.close();
+		}
+	}
+
+	/**
+	 * Obtain first child of given element with given name. null if not found
+	 */
+	private static Element getFirstChild(Element element, String name) {
+		for (Node child = element.getFirstChild(); child != null; child = child.getNextSibling()) {
+			if (child instanceof Element && name.equals(child.getNodeName())) {
+				return (Element) child;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Reads from an inputStream and returns a string; uses default charset for
+	 * stream -> char conversion. Closes inputStream.
+	 * 
+	 * @throws IOException
+	 */
+	private static String getString(InputStream inputStream) throws IOException {
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+		try {
+			transfer(inputStream, baos);
+
+			return baos.toString(); // Default encoding
+
+		} finally {
+			inputStream.close();
+		}
+	}
+
+	/**
+	 * Transfer inputStream to outputStream (InputStream.transferTo is not available
+	 * prior to java 9). Does not close input or output.
+	 * 
+	 * @param inputStream
+	 * @param outputStream
+	 * @throws IOException
+	 */
+	private static void transfer(InputStream inputStream, OutputStream outputStream) throws IOException {
+		byte[] buf = new byte[4096];
+		int length;
+		while ((length = inputStream.read(buf)) > 0) {
+			outputStream.write(buf, 0, length);
+		}
+	}
+}

--- a/dss-validation-esig-test/src/test/java/eu/europa/esig/dss/xades/validation/esig/test/EsigValidationCasesTest.java
+++ b/dss-validation-esig-test/src/test/java/eu/europa/esig/dss/xades/validation/esig/test/EsigValidationCasesTest.java
@@ -1,0 +1,271 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.xades.validation.esig.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.InMemoryDocument;
+import eu.europa.esig.dss.policy.ValidationPolicyFacade;
+import eu.europa.esig.dss.policy.jaxb.ConstraintsParameters;
+import eu.europa.esig.dss.service.crl.OnlineCRLSource;
+import eu.europa.esig.dss.service.http.commons.CommonsDataLoader;
+import eu.europa.esig.dss.service.http.commons.FileCacheDataLoader;
+import eu.europa.esig.dss.service.ocsp.OnlineOCSPSource;
+import eu.europa.esig.dss.simplereport.SimpleReport;
+import eu.europa.esig.dss.spi.client.http.DataLoader;
+import eu.europa.esig.dss.spi.tsl.LOTLInfo;
+import eu.europa.esig.dss.spi.tsl.TLValidationJobSummary;
+import eu.europa.esig.dss.spi.tsl.TrustedListsCertificateSource;
+import eu.europa.esig.dss.spi.x509.KeyStoreCertificateSource;
+import eu.europa.esig.dss.tsl.job.TLValidationJob;
+import eu.europa.esig.dss.tsl.source.LOTLSource;
+import eu.europa.esig.dss.validation.CertificateVerifier;
+import eu.europa.esig.dss.validation.CommonCertificateVerifier;
+import eu.europa.esig.dss.validation.SignedDocumentValidator;
+import eu.europa.esig.dss.validation.executor.ValidationLevel;
+import eu.europa.esig.dss.validation.reports.Reports;
+import eu.europa.esig.dss.xades.validation.esig.test.ESigValidationCasesRepository.ValidationTest;
+import eu.europa.esig.dss.xades.validation.esig.test.ESigValidationCasesRepository.LOTLConfig;
+import eu.europa.esig.trustedlist.TrustedListUtils;
+
+/**
+ * This class tests all validation cases provided by the Validation esig test
+ * cases project. See https://webgate.ec.europa.eu/esig-validation-tests/home
+ * <p>
+ * Note : as test cases largely depend on current date, test cases data is
+ * recreated every week. Therefore we start by downloading the latest test
+ * files.
+ * <p>
+ * By default, all validation cases are run. In order to run a specific set or a
+ * single validation case, a <code>eSigTestPrefixFilter</code> parameter may be
+ * passed on command line to filter tests based on their numeric prefix.
+ * Examples :
+ * <ul>
+ * <li><code>"mvn clean install -DargLine="-DeSigTestPrefixFilter=3.2.1-"</code>
+ * would run only test 3.2.1</li>
+ * <li><code>"mvn clean install -DargLine="-DeSigTestPrefixFilter=2."</code>
+ * would run all 2.*.* tests</li>
+ * </ul>
+ * 
+ * @author Nicolas ROY
+ */
+public class EsigValidationCasesTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(EsigValidationCasesTest.class);
+
+	/**
+	 * The configured LOTL configuration... Will change when testing, depending on
+	 * LOTL config required by test
+	 * 
+	 * Note : must be static, as parametrized tests instanciates this class for each
+	 * test
+	 */
+	private static LOTLConfig currentConfig;
+
+	private static TrustedListsCertificateSource trustedListsCertificateSource;
+
+	/**
+	 * If not null, will run tests starting with the given prefix
+	 */
+	private static final String RUN_ONLY_TEST_WITH_PREFIX = System.getProperty("eSigTestPrefixFilter");
+
+	/**
+	 * Obtain the collection of validationTests to run
+	 */
+	public static Iterable<? extends Object> getEsigValidationTestCases()
+			throws IOException, ParserConfigurationException, SAXException, KeyStoreException, NoSuchAlgorithmException,
+			CertificateException {
+		logger.info("Downloading and parsing Validation esig test cases...");
+		ESigValidationCasesRepository validationTestsRepository = new ESigValidationCasesRepository();
+
+		if (RUN_ONLY_TEST_WITH_PREFIX == null) {
+			logger.info("Runnning all Validation esig test cases as eSigTestPrefixFilter is null");
+			return validationTestsRepository.getValidationTests();
+
+		} else {
+			logger.info("Runnning only tests with prefix \"" + RUN_ONLY_TEST_WITH_PREFIX
+					+ "\" as eSigTestPrefixFilter property is set to this value.");
+			List<ValidationTest> result = new ArrayList<ESigValidationCasesRepository.ValidationTest>();
+			for (ValidationTest validationTest : validationTestsRepository.getValidationTests()) {
+				if (validationTest.getTestFile().getName().startsWith(RUN_ONLY_TEST_WITH_PREFIX)) {
+					result.add(validationTest);
+				}
+			}
+			return result;
+		}
+	}
+
+	/**
+	 * Init the LOTL for provided test. Will be done only if LOTL configuration
+	 * (i.e. URL) is different from previous call of this method.
+	 * 
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	public void initLotlIfNeeded(ValidationTest validationTest) throws IOException, InterruptedException {
+		// If current LOTL config is is not equal to the LOTL config we'll have to
+		// launch, then change it !
+		LOTLConfig nextConfig = validationTest.getLotlConfig();
+		if (!nextConfig.equals(currentConfig)) {
+
+			logger.info("Initializing TLManager with " + nextConfig);
+
+			// Disable validation of TrustLists, see : comment in TrustedListUtils shadow
+			// version for a full explanation.
+			TrustedListUtils.getInstance().setValidate(false);
+			try {
+				trustedListsCertificateSource = initLotl(nextConfig.getLotlUrl(), nextConfig.getLotlP12(),
+						nextConfig.getLotlP12Password());
+
+			} finally {
+				TrustedListUtils.getInstance().setValidate(true);
+			}
+			currentConfig = nextConfig;
+		}
+	}
+
+	/**
+	 * test the signature validation for a single ValidationTest
+	 * 
+	 * @throws InterruptedException
+	 */
+	@ParameterizedTest
+	@MethodSource("getEsigValidationTestCases")
+	public void testValidate(ValidationTest validationTest)
+			throws JAXBException, XMLStreamException, IOException, SAXException, InterruptedException {
+
+		this.initLotlIfNeeded(validationTest);
+
+		try {
+			ValidationPolicyFacade policyFacade = ValidationPolicyFacade.newFacade();
+			ConstraintsParameters constraints = policyFacade.unmarshall(new File("src/test/resources/constraint.xml"));
+
+			DSSDocument documentToValidate = new InMemoryDocument(new FileInputStream(validationTest.getTestFile()));
+			SignedDocumentValidator documentValidator = SignedDocumentValidator.fromDocument(documentToValidate);
+
+			CertificateVerifier certificateVerifier = new CommonCertificateVerifier();
+			certificateVerifier.setDataLoader(new CommonsDataLoader());
+			certificateVerifier.setDataLoader(getFileCacheDataLoader());
+			certificateVerifier.setCrlSource(new OnlineCRLSource(getFileCacheDataLoader()));
+			OnlineOCSPSource onlineOCSPSource = new OnlineOCSPSource();
+			onlineOCSPSource.setDataLoader(getFileCacheDataLoader());
+			certificateVerifier.setOcspSource(onlineOCSPSource);
+
+			certificateVerifier.setTrustedCertSources(trustedListsCertificateSource);
+
+			documentValidator.setCertificateVerifier(certificateVerifier);
+			documentValidator.setValidationLevel(ValidationLevel.ARCHIVAL_DATA);
+
+			Reports reports = documentValidator.validateDocument(constraints);
+			SimpleReport simpleReport = reports.getSimpleReport();
+
+			String firstSignatureId = simpleReport.getFirstSignatureId();
+
+			String actualResult = simpleReport.getSignatureQualification(firstSignatureId).getReadable();
+
+			assertEquals(validationTest.getExpectedConclusion(), actualResult,
+					"For " + validationTest.toString() + ", got unexpected level: " + actualResult + " (Expected: "
+							+ validationTest.getExpectedConclusion() + "). Subindication: "
+							+ simpleReport.getSubIndication(firstSignatureId) + ". ");
+
+		} catch (Exception e) {
+			logger.error("Exception for test " + validationTest + " : " + e);
+			throw e;
+		}
+	}
+
+	/**
+	 * Init with provided LOTL url, keystore and keystore password.
+	 * 
+	 * @throws IOException
+	 */
+	private static TrustedListsCertificateSource initLotl(String lotlUrl, File keystoreFile, String keystorePassword)
+			throws IOException {
+
+		TLValidationJob job = new TLValidationJob();
+		job.setOnlineDataLoader(new FileCacheDataLoader(new CommonsDataLoader()));
+
+		TrustedListsCertificateSource trustedListsCertificateSource = new TrustedListsCertificateSource();
+		job.setTrustedListCertificateSource(trustedListsCertificateSource);
+
+		KeyStoreCertificateSource keyStoreCertificateSource = new KeyStoreCertificateSource(keystoreFile, "PKCS12",
+				keystorePassword);
+
+		LOTLSource lotlSource = new LOTLSource();
+		lotlSource.setUrl(lotlUrl);
+		lotlSource.setCertificateSource(keyStoreCertificateSource);
+		lotlSource.setPivotSupport(true);
+
+		job.setListOfTrustedListSources(lotlSource);
+
+		// application initialization
+		job.onlineRefresh();
+
+		// check LOTL signature status
+		TLValidationJobSummary lotlValidation = job.getSummary();
+		for (LOTLInfo euLotlInfo : lotlValidation.getLOTLInfos()) {
+			assertFalse(euLotlInfo.getValidationCacheInfo().isError());
+			assertTrue(euLotlInfo.getValidationCacheInfo().isValid());
+		}
+
+		return trustedListsCertificateSource;
+	}
+
+	/**
+	 * Get file cache data loader to store docs that intervene in the validation
+	 * process
+	 * 
+	 * @return
+	 */
+	private DataLoader getFileCacheDataLoader() {
+		FileCacheDataLoader cacheDataLoader = new FileCacheDataLoader();
+
+		CommonsDataLoader dataLoader = new CommonsDataLoader();
+		cacheDataLoader.setDataLoader(dataLoader);
+
+		File rootFolder = new File(System.getProperty("java.io.tmpdir"));
+		File tslCache = new File(rootFolder, "dss-cache");
+		cacheDataLoader.setFileCacheDirectory(tslCache);
+		return cacheDataLoader;
+	}
+}

--- a/dss-validation-esig-test/src/test/java/eu/europa/esig/trustedlist/TrustedListUtils.java
+++ b/dss-validation-esig-test/src/test/java/eu/europa/esig/trustedlist/TrustedListUtils.java
@@ -1,0 +1,134 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * 
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.trustedlist;
+
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+
+import org.xml.sax.SAXException;
+
+import eu.europa.esig.trustedlist.jaxb.tsl.ObjectFactory;
+import eu.europa.esig.xades.XAdESUtils;
+import eu.europa.esig.xmldsig.XSDAbstractUtils;
+
+/**
+ * Shadow version of TrustedListUtils.
+ * 
+ * Explanation : specs-trusted-list (v5.6), provides XSD files to validate the
+ * trustlists XML (see dss-tsl-validation/xsd/*.xsd). Those XSD reference the
+ * XADES xsd in version 1.3.2 : http://uri.etsi.org/01903/v1.3.2/XAdES.xsd.
+ * 
+ * This XSD file does not support the SigningCertificateV2 attribute. But this
+ * attribute is used in the test validation trusted lists provided by CEF.
+ * Therefore loading of CEF test trustued lists fails with a parsing error
+ * (SigningCertificateV2 not expected).
+ * 
+ * Reference to http://uri.etsi.org/01903/v1.3.2/XAdES.xsd seems correct
+ * regarding ETSI TS 119 612 V1.1.1 (2013-06) which references explicitly this
+ * XSD URL. In later version of same ETSI TS 119 612 (2.1.1), the explicit
+ * reference to XSD URL was removed, but the document references ETSI TS 101 903
+ * (latest version), which does not talk about SigningCertificateV2 either.
+ * 
+ * In order to be able to use validation test cases, the easiest is to disable
+ * trust list validation. This requires shadowing TrustedListUtils as it can not
+ * be injected / manipulated in any wey in DSS (as well as TrustedListFacade).
+ */
+public final class TrustedListUtils extends XSDAbstractUtils {
+
+	public static final ObjectFactory OBJECT_FACTORY = new ObjectFactory();
+
+	public static final String TRUSTED_LIST_SCHEMA_LOCATION = "/xsd/ts_119612v020101_xsd.xsd";
+	public static final String TRUSTED_LIST_SIE_SCHEMA_LOCATION = "/xsd/ts_119612v020101_sie_xsd.xsd"; // NOPMD Not our
+																										// code (shadow
+																										// class)
+	public static final String TRUSTED_LIST_ADDITIONALTYPES_SCHEMA_LOCATION = "/xsd/ts_119612v020101_additionaltypes_xsd.xsd"; // NOPMD
+																																// Not
+																																// our
+																																// code
+																																// (shadow
+																																// class)
+
+	/**
+	 * NRO : A flag indicating if we will validate TrustedLists against schema, or
+	 * not.
+	 */
+	private boolean validate = true;
+
+	private static TrustedListUtils singleton;
+
+	private JAXBContext jc; // NOPMD Not our code (shadow class)
+
+	private TrustedListUtils() {
+	}
+
+	public static TrustedListUtils getInstance() {
+		if (singleton == null) { // NOPMD Not our code (shadow class)
+			singleton = new TrustedListUtils();
+		}
+		return singleton;
+	}
+
+	@Override
+	public JAXBContext getJAXBContext() throws JAXBException {
+		if (jc == null) {
+			jc = JAXBContext.newInstance(eu.europa.esig.xmldsig.jaxb.ObjectFactory.class,
+					eu.europa.esig.xades.jaxb.xades132.ObjectFactory.class,
+					eu.europa.esig.xades.jaxb.xades141.ObjectFactory.class, ObjectFactory.class,
+					eu.europa.esig.trustedlist.jaxb.tslx.ObjectFactory.class,
+					eu.europa.esig.trustedlist.jaxb.ecc.ObjectFactory.class);
+		}
+		return jc;
+	}
+
+	@Override
+	public Schema getSchema() throws SAXException {
+		if (validate) {
+			return super.getSchema();
+
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public List<Source> getXSDSources() {
+		List<Source> xsdSources = XAdESUtils.getInstance().getXSDSources();
+		xsdSources.add(new StreamSource(TrustedListUtils.class.getResourceAsStream(TRUSTED_LIST_SCHEMA_LOCATION)));
+		xsdSources.add(new StreamSource(TrustedListUtils.class.getResourceAsStream(TRUSTED_LIST_SIE_SCHEMA_LOCATION)));
+		xsdSources.add(new StreamSource(
+				TrustedListUtils.class.getResourceAsStream(TRUSTED_LIST_ADDITIONALTYPES_SCHEMA_LOCATION)));
+		return xsdSources;
+	}
+
+	public boolean isValidate() {
+		return validate;
+	}
+
+	public void setValidate(boolean validate) {
+		this.validate = validate;
+	}
+
+}

--- a/dss-validation-esig-test/src/test/resources/constraint.xml
+++ b/dss-validation-esig-test/src/test/resources/constraint.xml
@@ -1,0 +1,342 @@
+<ConstraintsParameters Name="QES AdESQC TL based" xmlns="http://dss.esig.europa.eu/validation/policy">
+	<Description>Validate electronic signatures and indicates whether they are Advanced electronic Signatures (AdES), AdES supported by a Qualified Certificate (AdES/QC) or a
+		Qualified electronic Signature (QES). All certificates and their related chains supporting the signatures are validated against the EU Member State Trusted Lists (this includes
+		signer's certificate and certificates used to validate certificate validity status services - CRLs, OCSP, and time-stamps).
+	</Description>
+	<ContainerConstraints>
+		<AcceptableContainerTypes Level="FAIL">
+			<Id>ASiC-S</Id>
+			<Id>ASiC-E</Id>
+		</AcceptableContainerTypes>
+<!-- 		<ZipCommentPresent Level="WARN" /> -->
+<!-- 		<AcceptableZipComment Level="WARN"> -->
+<!-- 			<Id>mimetype=application/vnd.etsi.asic-s+zip</Id> -->
+<!-- 			<Id>mimetype=application/vnd.etsi.asic-e+zip</Id> -->
+<!-- 		</AcceptableZipComment> -->
+		<MimeTypeFilePresent Level="FAIL" />
+		<AcceptableMimeTypeFileContent Level="WARN">
+			<Id>application/vnd.etsi.asic-s+zip</Id>
+			<Id>application/vnd.etsi.asic-e+zip</Id>
+		</AcceptableMimeTypeFileContent>
+		<ManifestFilePresent Level="FAIL" />
+		<SignedFilesPresent Level="FAIL" />
+		<AllFilesSigned Level="WARN" />
+	</ContainerConstraints>
+	<SignatureConstraints>
+		<StructuralValidation Level="WARN" />
+		<AcceptablePolicies Level="FAIL">
+			<Id>ANY_POLICY</Id>
+			<Id>NO_POLICY</Id>
+		</AcceptablePolicies>
+		<PolicyAvailable Level="FAIL" />
+		<PolicyHashMatch Level="FAIL" />
+		<AcceptableFormats Level="FAIL">
+			<Id>*</Id>
+		</AcceptableFormats>
+		<BasicSignatureConstraints>
+			<ReferenceDataExistence Level="FAIL" />
+			<ReferenceDataIntact Level="FAIL" />
+			<ManifestEntryObjectExistence Level="WARN" />
+			<SignatureIntact Level="FAIL" />
+			<SignatureDuplicated Level="FAIL" />
+			<ProspectiveCertificateChain Level="FAIL" />
+			<SignerInformationStore Level="FAIL" />
+<!-- 			<TrustedServiceTypeIdentifier Level="WARN"> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/Svctype/CA/QC</Id> -->
+<!-- 			</TrustedServiceTypeIdentifier> -->
+<!-- 			<TrustedServiceStatus Level="FAIL"> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/undersupervision</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/accredited</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/supervisionincessation</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/withdrawn</Id> -->
+<!-- 			</TrustedServiceStatus> -->
+			<SigningCertificate>
+				<Recognition Level="FAIL" />
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<AuthorityInfoAccessPresent Level="WARN" />
+				<RevocationInfoAccessPresent Level="WARN" />
+				<RevocationDataAvailable Level="FAIL" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<KeyUsage Level="WARN">
+					<Id>nonRepudiation</Id>
+				</KeyUsage>
+				<SerialNumberPresent Level="WARN" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<NotSelfSigned Level="WARN" />
+<!-- 				<Qualification Level="WARN" /> -->
+<!-- 				<SupportedByQSCD Level="WARN" /> -->
+<!-- 				<IssuedToNaturalPerson Level="INFORM" /> -->
+<!-- 				<IssuedToLegalPerson Level="INFORM" /> -->
+				<UsePseudonym Level="INFORM" />
+				<Cryptographic />
+			</SigningCertificate>
+			<CACertificate>
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<RevocationDataAvailable Level="FAIL" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<Cryptographic />
+			</CACertificate>
+			<Cryptographic />
+		</BasicSignatureConstraints>
+		<SignedAttributes>
+			<SigningCertificatePresent Level="FAIL" />
+			<UnicitySigningCertificate Level="WARN" />
+			<CertDigestPresent Level="FAIL" />
+			<CertDigestMatch Level="FAIL" />
+			<IssuerSerialMatch Level="WARN" />
+			<SigningTime Level="FAIL" />
+			<MessageDigestOrSignedPropertiesPresent Level="FAIL" />
+<!--		<ContentType Level="FAIL" value="1.2.840.113549.1.7.1" />
+			<ContentHints Level="FAIL" value="*" />
+			<CommitmentTypeIndication Level="FAIL">
+				<Id>1.2.840.113549.1.9.16.6.1</Id>
+				<Id>1.2.840.113549.1.9.16.6.4</Id>
+				<Id>1.2.840.113549.1.9.16.6.5</Id>
+				<Id>1.2.840.113549.1.9.16.6.6</Id>
+			</CommitmentTypeIndication>
+			<SignerLocation Level="FAIL" />
+			<ContentTimeStamp Level="FAIL" /> -->
+		</SignedAttributes>
+		<UnsignedAttributes>
+<!--		<CounterSignature Level="IGNORE" /> check presence -->
+		</UnsignedAttributes>
+	</SignatureConstraints>
+	<CounterSignatureConstraints>
+		<BasicSignatureConstraints>
+			<ReferenceDataExistence Level="FAIL" />
+			<ReferenceDataIntact Level="FAIL" />
+			<SignatureIntact Level="FAIL" />
+			<SignatureDuplicated Level="FAIL" />
+			<ProspectiveCertificateChain Level="FAIL" />
+<!-- 			<TrustedServiceTypeIdentifier Level="WARN"> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/Svctype/CA/QC</Id> -->
+<!-- 			</TrustedServiceTypeIdentifier> -->
+<!-- 			<TrustedServiceStatus Level="FAIL"> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/undersupervision</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/accredited</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/supervisionincessation</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted</Id> -->
+<!-- 				<Id>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/withdrawn</Id> -->
+<!-- 			</TrustedServiceStatus> -->
+			<SigningCertificate>
+				<Recognition Level="FAIL" />
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<AuthorityInfoAccessPresent Level="WARN" />
+				<RevocationInfoAccessPresent Level="WARN" />
+				<RevocationDataAvailable Level="FAIL" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<KeyUsage Level="WARN">
+					<Id>nonRepudiation</Id>
+				</KeyUsage>
+				<SerialNumberPresent Level="WARN" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<NotSelfSigned Level="WARN" />
+<!-- 				<Qualification Level="WARN" /> -->
+<!-- 				<SupportedByQSCD Level="WARN" /> -->
+<!-- 				<IssuedToNaturalPerson Level="INFORM" /> -->
+<!-- 				<IssuedToLegalPerson Level="INFORM" /> -->
+				<UsePseudonym Level="INFORM" />
+				<Cryptographic />
+			</SigningCertificate>
+			<CACertificate>
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<RevocationDataAvailable Level="FAIL" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<Cryptographic />
+			</CACertificate>
+			<Cryptographic />
+		</BasicSignatureConstraints>
+		<SignedAttributes>
+			<SigningCertificatePresent Level="FAIL" />
+			<CertDigestPresent Level="FAIL" />
+			<CertDigestMatch Level="FAIL" />
+			<IssuerSerialMatch Level="WARN" />
+			<SigningTime Level="FAIL" />
+			<MessageDigestOrSignedPropertiesPresent Level="FAIL" />
+<!--		<ContentType Level="FAIL" value="1.2.840.113549.1.7.1" />
+			<ContentHints Level="FAIL" value="*" />
+			<CommitmentTypeIndication Level="FAIL">
+				<Id>1.2.840.113549.1.9.16.6.1</Id>
+				<Id>1.2.840.113549.1.9.16.6.4</Id>
+				<Id>1.2.840.113549.1.9.16.6.5</Id>
+				<Id>1.2.840.113549.1.9.16.6.6</Id>
+			</CommitmentTypeIndication>
+			<SignerLocation Level="FAIL" />
+			<ContentTimeStamp Level="FAIL" /> -->
+		</SignedAttributes>
+	</CounterSignatureConstraints>
+	<Timestamp>
+		<TimestampDelay Level="IGNORE" Unit="DAYS" Value="0" />
+		<RevocationTimeAgainstBestSignatureTime	Level="FAIL" />
+		<BestSignatureTimeBeforeExpirationDateOfSigningCertificate Level="FAIL" />
+		<Coherence Level="WARN" />
+		<BasicSignatureConstraints>
+			<ReferenceDataExistence Level="FAIL" />
+			<ReferenceDataIntact Level="FAIL" />
+			<SignatureIntact Level="FAIL" />
+			<ProspectiveCertificateChain Level="FAIL" />
+			<SigningCertificate>
+				<Recognition Level="FAIL" />
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<RevocationDataAvailable Level="FAIL" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<ExtendedKeyUsage Level="WARN">
+					<Id>timeStamping</Id>
+				</ExtendedKeyUsage>
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<NotSelfSigned Level="WARN" />
+				<Cryptographic />
+			</SigningCertificate>
+			<CACertificate>
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<RevocationDataAvailable Level="WARN" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<Cryptographic />
+			</CACertificate>
+			<Cryptographic />
+		</BasicSignatureConstraints>
+		<SignedAttributes>
+			<SigningCertificatePresent Level="WARN" />
+			<UnicitySigningCertificate Level="WARN" />
+			<CertDigestPresent Level="WARN" />
+			<CertDigestMatch Level="WARN" />
+			<IssuerSerialMatch Level="WARN" />
+		</SignedAttributes>
+	</Timestamp>
+	<Revocation>
+        <RevocationFreshness Level="IGNORE" Unit="DAYS" Value="0" />
+        <UnknownStatus Level="FAIL" />
+		<BasicSignatureConstraints>
+			<ReferenceDataExistence Level="FAIL" />
+			<ReferenceDataIntact Level="FAIL" />
+			<SignatureIntact Level="FAIL" />
+			<ProspectiveCertificateChain Level="FAIL" />
+			<SigningCertificate>
+				<Recognition Level="FAIL" />
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<RevocationDataAvailable Level="FAIL" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<Cryptographic />
+			</SigningCertificate>
+			<CACertificate>
+				<Signature Level="FAIL" />
+				<NotExpired Level="FAIL" />
+				<RevocationDataAvailable Level="WARN" />
+				<RevocationDataNextUpdatePresent Level="WARN" />
+				<RevocationDataFreshness Level="FAIL" />
+				<NotRevoked Level="FAIL" />
+				<NotOnHold Level="FAIL" />
+				<Cryptographic />
+			</CACertificate>
+			<Cryptographic />
+		</BasicSignatureConstraints>
+	</Revocation>
+	<Cryptographic Level="FAIL">
+		<AcceptableEncryptionAlgo>
+			<Algo>RSA</Algo>
+			<Algo>DSA</Algo>
+			<Algo>ECDSA</Algo>
+			<Algo>PLAIN-ECDSA</Algo>
+<!-- 		<Algo>Ed25519</Algo> 				Not referenced in ETSI/SOGIS -->
+		</AcceptableEncryptionAlgo>
+		<MiniPublicKeySize>
+			<Algo Size="160">DSA</Algo>
+			<Algo Size="1024">RSA</Algo>
+			<Algo Size="160">ECDSA</Algo>
+			<Algo Size="160">PLAIN-ECDSA</Algo>
+<!-- 		<Algo Size="24">Ed25519</Algo> 		Not referenced in ETSI/SOGIS -->
+		</MiniPublicKeySize>
+		<AcceptableDigestAlgo>
+			<Algo>MD2</Algo>
+			<Algo>MD5</Algo>
+			<Algo>SHA1</Algo>
+			<Algo>SHA224</Algo>
+			<Algo>SHA256</Algo>
+			<Algo>SHA384</Algo>
+			<Algo>SHA512</Algo>
+			<Algo>SHA3-224</Algo>
+			<Algo>SHA3-256</Algo>
+			<Algo>SHA3-384</Algo>
+			<Algo>SHA3-512</Algo>
+			<Algo>RIPEMD160</Algo>
+			<Algo>WHIRLPOOL</Algo>
+		</AcceptableDigestAlgo>
+		<AlgoExpirationDate Format="yyyy">
+			<!-- Digest algorithms -->
+			<Algo Date="2005">MD2</Algo> <!-- The same as for MD5 -->
+			<Algo Date="2005">MD5</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2009">SHA1</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.0.0 -->
+			<Algo Date="2023">SHA224</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA256</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA384</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA512</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA3-224</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA3-256</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA3-384</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026">SHA3-512</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2011">RIPEMD160</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.0.0 -->
+			<Algo Date="2015">WHIRLPOOL</Algo> <!-- ETSI 119 312 V1.1.1 -->
+			<!-- end Digest algorithms -->
+			<!-- Encryption algorithms -->
+			<Algo Date="2013" Size="160">DSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2013" Size="192">DSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2023" Size="224">DSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026" Size="256">DSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2009" Size="1024">RSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.0.0 -->
+			<Algo Date="2016" Size="1536">RSA</Algo> <!-- ETSI 119 312 V1.1.1 -->
+			<Algo Date="2023" Size="1900">RSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026" Size="3000">RSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2013" Size="160">ECDSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2013" Size="192">ECDSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2016" Size="224">ECDSA</Algo> <!-- ETSI 119 312 V1.1.1 -->
+			<Algo Date="2026" Size="256">ECDSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026" Size="384">ECDSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026" Size="512">ECDSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2013" Size="160">PLAIN-ECDSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2013" Size="192">PLAIN-ECDSA</Algo> <!-- ETSI TS 102 176-1 (Historical) V2.1.1 -->
+			<Algo Date="2016" Size="224">PLAIN-ECDSA</Algo> <!-- ETSI 119 312 V1.1.1 -->
+			<Algo Date="2026" Size="256">PLAIN-ECDSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026" Size="384">PLAIN-ECDSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			<Algo Date="2026" Size="512">PLAIN-ECDSA</Algo> <!-- ETSI 119 312 V1.3.1 -->
+			
+<!-- 		<Algo Date="2026" Size="32">Ed25519</Algo> 		Not referenced in ETSI/SOGIS -->
+			<!-- end Encryption algorithms -->
+		</AlgoExpirationDate>
+	</Cryptographic> 
+	
+	<Model Value="SHELL" />
+	
+	<!-- eIDAS REGL 910/EU/2014 --> 
+	<eIDAS>
+		<TLFreshness Level="WARN" Unit="HOURS" Value="6" />
+		<TLNotExpired Level="WARN" />
+		<TLWellSigned Level="WARN" />
+		<TLVersion Level="FAIL" value="5" />
+	</eIDAS>
+</ConstraintsParameters>


### PR DESCRIPTION
DSS-2393 Junit tests for eSignature validation test cases

This new module named "dss-validation-esig-test" is a proposal for addressing DSS-2393.
It contains only Junit tests, which dynamically download the cases from  "eSignature validation test cases" project, and run them.

At the time of creation of this pull request : 92 Tests are run, of which 28 fail (unexpected qualification level), as described in DSS-2291. This new module was not added to the parent pom, to prevent any test failure in the global build.

 By default, all validation cases are run. In order to run a specific set or a single validation case, a parameter named "eSigTestPrefixFilter" may be passed on command line to filter the tests run, based on their numeric prefix.

Examples :
  - mvn clean install  => Runs all tests (i.e. all cases listed on https://webgate.ec.europa.eu/esig-validation-tests/testcases)
  - mvn clean install -DargLine="-DeSigTestPrefixFilter=3.2.1-" => would run only test 3.2.1 
  - mvn clean install -DargLine="-DeSigTestPrefixFilter=2." => would run all 2.*.* tests
 