### PR TITLE
DSS-2437, DSS-2438: Simplify native pdf drawer

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
@@ -241,12 +241,6 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 				float yAxis = dimensionAndPosition.getImageY();
 				float width = dimensionAndPosition.getImageWidth();
 				float height = dimensionAndPosition.getImageHeight();
-				if (!parameters.getTextParameters().isEmpty()) {
-					xAxis *= dimensionAndPosition.getxDpiRatio();
-					yAxis *= dimensionAndPosition.getyDpiRatio();
-					width *= dimensionAndPosition.getxDpiRatio();
-					height *= dimensionAndPosition.getyDpiRatio();
-				}
 
 				cs.drawImage(imageXObject, xAxis, yAxis, width, height);
 				cs.transform(Matrix.getRotateInstance(

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
@@ -284,11 +284,8 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 
 			String[] strings = pdfBoxFontMetrics.getLines(textParameters.getText());
 
-			float properSize = CommonDrawerUtils.computeProperSize(textParameters.getFont().getSize(),
-					parameters.getDpi());
-
-			float fontHeight = pdfBoxFontMetrics.getHeight(textParameters.getText(), properSize);
-			cs.setLeading(textSizeWithDpi(fontHeight, dimensionAndPosition.getyDpi()));
+			float lineHeight = pdfBoxFontMetrics.getHeight(textParameters.getText(), textParameters.getFont().getSize());
+			cs.setLeading(lineHeight);
 
 			cs.newLineAtOffset(dimensionAndPosition.getTextX(),
 					// align vertical position
@@ -301,12 +298,12 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 				switch (textParameters.getSignerTextHorizontalAlignment()) {
 				case RIGHT:
 					offsetX = dimensionAndPosition.getTextWidth() - stringWidth
-							- textSizeWithDpi(textParameters.getPadding() * 2, dimensionAndPosition.getxDpi())
+							- textSizeWithDpi(textParameters.getPadding() * 2)
 							- previousOffset;
 					break;
 				case CENTER:
 					offsetX = (dimensionAndPosition.getTextWidth() - stringWidth) / 2
-							- textSizeWithDpi(textParameters.getPadding(), dimensionAndPosition.getxDpi())
+							- textSizeWithDpi(textParameters.getPadding())
 							- previousOffset;
 					break;
 				default:
@@ -327,17 +324,16 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 		if (textParameters.getBackgroundColor() != null) {
 			PDRectangle rect = new PDRectangle(
 					dimensionAndPosition.getTextX()
-							- textSizeWithDpi(textParameters.getPadding(), dimensionAndPosition.getxDpi()),
+							- textSizeWithDpi(textParameters.getPadding()),
 					dimensionAndPosition.getTextY()
-							+ textSizeWithDpi(textParameters.getPadding(), dimensionAndPosition.getyDpi()),
+							+ textSizeWithDpi(textParameters.getPadding()),
 					dimensionAndPosition.getTextWidth(), dimensionAndPosition.getTextHeight());
 			setBackground(cs, textParameters.getBackgroundColor(), rect);
 		}
 	}
 
-	private float textSizeWithDpi(float size, int dpi) {
-		return CommonDrawerUtils.toDpiAxisPoint(size / CommonDrawerUtils.getTextScaleFactor(dpi), dpi)
-				* CommonDrawerUtils.getTextScaleFactor(parameters.getDpi());
+	private float textSizeWithDpi(float size) {
+		return CommonDrawerUtils.toDpiAxisPoint(size, parameters.getDpi());
 	}
 
 	/**

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
@@ -188,11 +188,11 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 	}
 	
 	public void paddingShift(float padding) {
-		this.textX += CommonDrawerUtils.toDpiAxisPoint(padding / CommonDrawerUtils.getTextScaleFactor(getxDpi()), getxDpi()) * 
-				CommonDrawerUtils.getTextScaleFactor(imageDpi);
+		float nonZeroDpi = CommonDrawerUtils.getDpi(imageDpi);
+		float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(padding, nonZeroDpi);
+		this.textX += scaledPadding;
 		// minus, because PDF starts to count from bottom
-		this.textY -= CommonDrawerUtils.toDpiAxisPoint(padding / CommonDrawerUtils.getTextScaleFactor(getyDpi()), getyDpi()) * 
-				CommonDrawerUtils.getTextScaleFactor(imageDpi);
+		this.textY -= scaledPadding;
 	}
 
 	@Override

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
@@ -22,7 +22,6 @@ package eu.europa.esig.dss.pdf.pdfbox.visible.nativedrawer;
 
 import eu.europa.esig.dss.pdf.AnnotationBox;
 import eu.europa.esig.dss.pdf.visible.CommonDrawerUtils;
-import eu.europa.esig.dss.pdf.visible.ImageAndResolution;
 import eu.europa.esig.dss.pdf.visible.VisualSignatureFieldAppearance;
 
 public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldAppearance {
@@ -42,15 +41,8 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 	private float textWidth = 0;
 	private float textHeight = 0;
 	
-	private ImageAndResolution imageAndResolution;
-	
-	private int imageDpi;
-	
 	private int globalRotation;
 
-	private static final int DEFAULT_DPI = 72;
-	private static final int DEFAULT_TEXT_DPI = 300;
-	
 	public float getBoxX() {
 		return boxX;
 	}
@@ -146,15 +138,7 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 	public void setTextHeight(float textHeight) {
 		this.textHeight = textHeight;
 	}
-	
-	public void setImageAndResolution(ImageAndResolution imageAndResolution) {
-		this.imageAndResolution = imageAndResolution;
-	}
 
-	public void setImageDpi(int imageDpi) {
-		this.imageDpi = imageDpi;
-	}
-	
 	public int getGlobalRotation() {
 		return globalRotation;
 	}
@@ -163,33 +147,8 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 		this.globalRotation = globalRotation;
 	}
 	
-	public int getxDpi() {
-		if (imageAndResolution != null) {
-			return imageAndResolution.getxDpi();
-		} else {
-			return DEFAULT_TEXT_DPI;
-		}
-	}
-	
-	public int getyDpi() {
-		if (imageAndResolution != null) {
-			return imageAndResolution.getyDpi();
-		} else {
-			return DEFAULT_TEXT_DPI;
-		}
-	}
-	
-	public float getxDpiRatio() {
-		return (float) DEFAULT_DPI / getxDpi();
-	}
-	
-	public float getyDpiRatio() {
-		return (float) DEFAULT_DPI / getyDpi();
-	}
-	
-	public void paddingShift(float padding) {
-		float nonZeroDpi = CommonDrawerUtils.getDpi(imageDpi);
-		float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(padding, nonZeroDpi);
+	public void paddingShift(float padding, Integer imageDpi) {
+		float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(padding, imageDpi);
 		this.textX += scaledPadding;
 		// minus, because PDF starts to count from bottom
 		this.textY -= scaledPadding;

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
@@ -65,6 +65,11 @@ public class SignatureFieldDimensionAndPositionBuilder {
 	private static final String NOT_SUPPORTED_VERTICAL_ALIGNMENT_ERROR_MESSAGE = "not supported vertical alignment: ";
 	private static final String NOT_SUPPORTED_HORIZONTAL_ALIGNMENT_ERROR_MESSAGE = "not supported horizontal alignment: ";
 
+	private static final int DEFAULT_DPI = CommonDrawerUtils.getDpi(null);
+
+	private int xDpi;
+	private int yDpi;
+
 	/**
 	 * Default constructor
 	 *
@@ -101,13 +106,16 @@ public class SignatureFieldDimensionAndPositionBuilder {
 			ImageAndResolution imageAndResolution;
 			try {
 				imageAndResolution = ImageUtils.readDisplayMetadata(imageParameters.getImage());
+				xDpi = imageAndResolution.getxDpi();
+				yDpi = imageAndResolution.getyDpi();
 			} catch (Exception e) {
 				LOG.warn("Cannot access the image metadata : {}. Returns default info.", e.getMessage());
-				imageAndResolution = new ImageAndResolution(imageParameters.getImage(), imageParameters.getDpi(),
-						imageParameters.getDpi());
+				xDpi = imageParameters.getDpi();
+				yDpi = imageParameters.getDpi();
 			}
-			dimensionAndPosition.setImageAndResolution(imageAndResolution);
-			dimensionAndPosition.setImageDpi(imageParameters.getDpi());
+		} else {
+			xDpi = DEFAULT_DPI;
+			yDpi = DEFAULT_DPI;
 		}
 	}
 
@@ -118,10 +126,10 @@ public class SignatureFieldDimensionAndPositionBuilder {
 
 		SignatureFieldParameters fieldParameters = imageParameters.getFieldParameters();
 		if (fieldParameters.getWidth() == 0) {
-			imageWidth *= CommonDrawerUtils.getPageScaleFactor(dimensionAndPosition.getxDpi());
+			imageWidth *= CommonDrawerUtils.getPageScaleFactor(xDpi);
 		}
 		if (fieldParameters.getHeight() == 0) {
-			imageHeight *= CommonDrawerUtils.getPageScaleFactor(dimensionAndPosition.getyDpi());
+			imageHeight *= CommonDrawerUtils.getPageScaleFactor(yDpi);
 		}
 
 		float width = imageWidth;
@@ -191,7 +199,8 @@ public class SignatureFieldDimensionAndPositionBuilder {
 
 			dimensionAndPosition.setTextWidth(textWidth);
 			dimensionAndPosition.setTextHeight(textHeight);
-			dimensionAndPosition.paddingShift(textParameters.getPadding());
+			Integer imageDpi = imageParameters.getImage() != null ? imageParameters.getDpi() : DEFAULT_DPI;
+			dimensionAndPosition.paddingShift(textParameters.getPadding(), imageDpi);
 		}
 
 		int rotation = ImageRotationUtils.getRotation(imageParameters.getRotation(), page);

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
@@ -131,20 +131,10 @@ public class SignatureFieldDimensionAndPositionBuilder {
 		// if text is present
 		if (!textParameters.isEmpty()) {
 
-			// adds an empty space
-			imageWidth = toDpiTextPoint(imageWidth, dimensionAndPosition.getxDpi());
-			imageHeight = toDpiTextPoint(imageHeight, dimensionAndPosition.getyDpi());
-			width = imageWidth;
-			height = imageHeight;
-
 			// native implementation uses dpi-independent font
 			AnnotationBox textBox = computeTextDimension(textParameters);
-			float textWidth = textBox.getWidth() * CommonDrawerUtils.getTextScaleFactor(imageParameters.getDpi());
-			float textHeight = textBox.getHeight() * CommonDrawerUtils.getTextScaleFactor(imageParameters.getDpi());
-			if (imageParameters.getImage() != null) {
-				textWidth /= CommonDrawerUtils.getTextScaleFactor(dimensionAndPosition.getxDpi());
-				textHeight /= CommonDrawerUtils.getTextScaleFactor(dimensionAndPosition.getyDpi());
-			}
+			float textWidth = textBox.getWidth();
+			float textHeight = textBox.getHeight();
 
 			switch (textParameters.getSignerTextPosition()) {
 			case LEFT:
@@ -168,7 +158,7 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				if (fieldParameters.getHeight() == 0) {
 					height = Math.max(height, textHeight);
 				}
-				dimensionAndPosition.setTextX(toDpiPagePoint(width - textWidth, dimensionAndPosition.getxDpi()));
+				dimensionAndPosition.setTextX(width - textWidth);
 				textImageVerticalAlignment(height, imageHeight, textHeight);
 				break;
 			case TOP:
@@ -180,7 +170,7 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				} else {
 					imageHeight -= imageParameters.getImage() != null || height == 0 ? textHeight : 0;
 				}
-				dimensionAndPosition.setTextY(toDpiPagePoint(height - textHeight, dimensionAndPosition.getyDpi()));
+				dimensionAndPosition.setTextY(height - textHeight);
 				textImageHorizontalAlignment(width, imageWidth, textWidth);
 				break;
 			case BOTTOM:
@@ -199,12 +189,9 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				break;
 			}
 
-			dimensionAndPosition.setTextWidth(toDpiPagePoint(textWidth, dimensionAndPosition.getxDpi()));
-			dimensionAndPosition.setTextHeight(toDpiPagePoint(textHeight, dimensionAndPosition.getyDpi()));
+			dimensionAndPosition.setTextWidth(textWidth);
+			dimensionAndPosition.setTextHeight(textHeight);
 			dimensionAndPosition.paddingShift(textParameters.getPadding());
-
-			width = toDpiPagePoint(width, dimensionAndPosition.getxDpi());
-			height = toDpiPagePoint(height, dimensionAndPosition.getyDpi());
 		}
 
 		int rotation = ImageRotationUtils.getRotation(imageParameters.getRotation(), page);
@@ -224,13 +211,12 @@ public class SignatureFieldDimensionAndPositionBuilder {
 	}
 
 	private AnnotationBox computeTextDimension(SignatureImageTextParameters textParameters) throws IOException {
-		float properSize = CommonDrawerUtils.computeProperSize(textParameters.getFont().getSize(),
-				imageParameters.getDpi());
-		properSize *= ImageUtils.getScaleFactor(imageParameters.getZoom()); // scale text block
+		float properSize = textParameters.getFont().getSize()
+				* ImageUtils.getScaleFactor(imageParameters.getZoom()); // scale text block
 
 		PdfBoxFontMetrics pdfBoxFontMetrics = new PdfBoxFontMetrics(pdFont);
 		return pdfBoxFontMetrics.computeTextBoundaryBox(textParameters.getText(), properSize,
-				textParameters.getPadding());
+				CommonDrawerUtils.toDpiAxisPoint(textParameters.getPadding(), imageParameters.getDpi()));
 	}
 
 	private void textImageVerticalAlignment(double height, double imageHeight, float textHeight) {
@@ -238,7 +224,7 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				.getSignerTextVerticalAlignment();
 		switch (verticalAlignment) {
 		case TOP:
-			dimensionAndPosition.setTextY(toDpiPagePoint((height - textHeight), dimensionAndPosition.getyDpi()));
+			dimensionAndPosition.setTextY((float) (height - textHeight));
 			dimensionAndPosition.setImageY((float) (height - imageHeight));
 			break;
 		case BOTTOM:
@@ -246,7 +232,7 @@ public class SignatureFieldDimensionAndPositionBuilder {
 			dimensionAndPosition.setImageY(0);
 			break;
 		case MIDDLE:
-			dimensionAndPosition.setTextY(toDpiPagePoint((height - textHeight) / 2, dimensionAndPosition.getyDpi()));
+			dimensionAndPosition.setTextY((float) (height - textHeight) / 2);
 			dimensionAndPosition.setImageY((float) (height - imageHeight) / 2);
 			break;
 		default:
@@ -263,11 +249,11 @@ public class SignatureFieldDimensionAndPositionBuilder {
 			dimensionAndPosition.setImageX(0);
 			break;
 		case RIGHT:
-			dimensionAndPosition.setTextX(toDpiPagePoint((width - textWidth), dimensionAndPosition.getxDpi()));
+			dimensionAndPosition.setTextX((float) (width - textWidth));
 			dimensionAndPosition.setImageX((float) (width - imageWidth));
 			break;
 		case CENTER:
-			dimensionAndPosition.setTextX(toDpiPagePoint((width - textWidth) / 2, dimensionAndPosition.getxDpi()));
+			dimensionAndPosition.setTextX((float) (width - textWidth) / 2);
 			dimensionAndPosition.setImageX((float) (width - imageWidth) / 2);
 			break;
 		default:
@@ -353,16 +339,6 @@ public class SignatureFieldDimensionAndPositionBuilder {
 		default:
 			throw new IllegalStateException(ImageRotationUtils.SUPPORTED_ANGLES_ERROR_MESSAGE);
 		}
-	}
-
-	// decrease size
-	private float toDpiPagePoint(double x, Integer dpi) {
-		return CommonDrawerUtils.toDpiAxisPoint((float) x, CommonDrawerUtils.getDpi(dpi));
-	}
-
-	// increase size
-	private float toDpiTextPoint(double x, Integer dpi) {
-		return CommonDrawerUtils.computeProperSize((float) x, CommonDrawerUtils.getDpi(dpi));
 	}
 
 }

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
@@ -219,28 +219,28 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				CommonDrawerUtils.toDpiAxisPoint(textParameters.getPadding(), imageParameters.getDpi()));
 	}
 
-	private void textImageVerticalAlignment(double height, double imageHeight, float textHeight) {
+	private void textImageVerticalAlignment(float height, float imageHeight, float textHeight) {
 		SignerTextVerticalAlignment verticalAlignment = imageParameters.getTextParameters()
 				.getSignerTextVerticalAlignment();
 		switch (verticalAlignment) {
 		case TOP:
-			dimensionAndPosition.setTextY((float) (height - textHeight));
-			dimensionAndPosition.setImageY((float) (height - imageHeight));
+			dimensionAndPosition.setTextY(height - textHeight);
+			dimensionAndPosition.setImageY(height - imageHeight);
 			break;
 		case BOTTOM:
 			dimensionAndPosition.setTextY(0);
 			dimensionAndPosition.setImageY(0);
 			break;
 		case MIDDLE:
-			dimensionAndPosition.setTextY((float) (height - textHeight) / 2);
-			dimensionAndPosition.setImageY((float) (height - imageHeight) / 2);
+			dimensionAndPosition.setTextY((height - textHeight) / 2);
+			dimensionAndPosition.setImageY((height - imageHeight) / 2);
 			break;
 		default:
 			throw new IllegalStateException(NOT_SUPPORTED_VERTICAL_ALIGNMENT_ERROR_MESSAGE + verticalAlignment);
 		}
 	}
 
-	private void textImageHorizontalAlignment(double width, double imageWidth, float textWidth) {
+	private void textImageHorizontalAlignment(float width, float imageWidth, float textWidth) {
 		SignerTextHorizontalAlignment horizontalAlignment = imageParameters.getTextParameters()
 				.getSignerTextHorizontalAlignment();
 		switch (horizontalAlignment) {
@@ -249,12 +249,12 @@ public class SignatureFieldDimensionAndPositionBuilder {
 			dimensionAndPosition.setImageX(0);
 			break;
 		case RIGHT:
-			dimensionAndPosition.setTextX((float) (width - textWidth));
-			dimensionAndPosition.setImageX((float) (width - imageWidth));
+			dimensionAndPosition.setTextX(width - textWidth);
+			dimensionAndPosition.setImageX(width - imageWidth);
 			break;
 		case CENTER:
-			dimensionAndPosition.setTextX((float) (width - textWidth) / 2);
-			dimensionAndPosition.setImageX((float) (width - imageWidth) / 2);
+			dimensionAndPosition.setTextX((width - textWidth) / 2);
+			dimensionAndPosition.setImageX((width - imageWidth) / 2);
 			break;
 		default:
 			throw new IllegalStateException(NOT_SUPPORTED_HORIZONTAL_ALIGNMENT_ERROR_MESSAGE + horizontalAlignment);


### PR DESCRIPTION
This PR addresses the issues raised in both DSS-2437 and DSS-2438. It then goes further and removes a lot of redundant calculations in `SignatureFieldDimensionAndPositionBuilder`.

The last commit of the bunch moves some code from `SignatureFieldDimensionAndPosition` into `SignatureFieldDimensionAndPositionBuilder`. At this point, that code was only being set up and called by `SignatureFieldDimensionAndPositionBuilder` and so I felt its purpose was being obfuscated by keeping it where it was. This is however a non-essential change so feel free to ignore that particular commit if you feel it is an overreach.