### PR TITLE
DSS-2458: encapsulate padding calculations

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
@@ -281,10 +281,9 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 			float lineHeight = pdfBoxFontMetrics.getHeight(textParameters.getText(), textParameters.getFont().getSize());
 			cs.setLeading(lineHeight);
 
-			float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(textParameters.getPadding(), parameters.getDpi());
-			cs.newLineAtOffset(dimensionAndPosition.getTextX() + scaledPadding,
+			cs.newLineAtOffset(dimensionAndPosition.getTextX(),
 					// align vertical position
-					dimensionAndPosition.getTextHeight() + dimensionAndPosition.getTextY() - scaledPadding - fontSize);
+					dimensionAndPosition.getTextHeight() + dimensionAndPosition.getTextY() - fontSize);
 
 			float previousOffset = 0;
 			for (String str : strings) {
@@ -293,12 +292,10 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 				switch (textParameters.getSignerTextHorizontalAlignment()) {
 				case RIGHT:
 					offsetX = dimensionAndPosition.getTextWidth() - stringWidth
-							- (2 * scaledPadding)
 							- previousOffset;
 					break;
 				case CENTER:
 					offsetX = (dimensionAndPosition.getTextWidth() - stringWidth) / 2
-							- scaledPadding
 							- previousOffset;
 					break;
 				default:
@@ -318,8 +315,8 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 			SignatureFieldDimensionAndPosition dimensionAndPosition) throws IOException {
 		if (textParameters.getBackgroundColor() != null) {
 			PDRectangle rect = new PDRectangle(
-					dimensionAndPosition.getTextX(), dimensionAndPosition.getTextY(),
-					dimensionAndPosition.getTextWidth(), dimensionAndPosition.getTextHeight());
+					dimensionAndPosition.getTextBoxX(), dimensionAndPosition.getTextBoxY(),
+					dimensionAndPosition.getTextBoxWidth(), dimensionAndPosition.getTextBoxHeight());
 			setBackground(cs, textParameters.getBackgroundColor(), rect);
 		}
 	}

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
@@ -281,9 +281,10 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 			float lineHeight = pdfBoxFontMetrics.getHeight(textParameters.getText(), textParameters.getFont().getSize());
 			cs.setLeading(lineHeight);
 
-			cs.newLineAtOffset(dimensionAndPosition.getTextX(),
+			float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(textParameters.getPadding(), parameters.getDpi());
+			cs.newLineAtOffset(dimensionAndPosition.getTextX() + scaledPadding,
 					// align vertical position
-					dimensionAndPosition.getTextHeight() + dimensionAndPosition.getTextY() - fontSize);
+					dimensionAndPosition.getTextHeight() + dimensionAndPosition.getTextY() - scaledPadding - fontSize);
 
 			float previousOffset = 0;
 			for (String str : strings) {
@@ -292,12 +293,12 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 				switch (textParameters.getSignerTextHorizontalAlignment()) {
 				case RIGHT:
 					offsetX = dimensionAndPosition.getTextWidth() - stringWidth
-							- textSizeWithDpi(textParameters.getPadding() * 2)
+							- (2 * scaledPadding)
 							- previousOffset;
 					break;
 				case CENTER:
 					offsetX = (dimensionAndPosition.getTextWidth() - stringWidth) / 2
-							- textSizeWithDpi(textParameters.getPadding())
+							- scaledPadding
 							- previousOffset;
 					break;
 				default:
@@ -317,17 +318,10 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 			SignatureFieldDimensionAndPosition dimensionAndPosition) throws IOException {
 		if (textParameters.getBackgroundColor() != null) {
 			PDRectangle rect = new PDRectangle(
-					dimensionAndPosition.getTextX()
-							- textSizeWithDpi(textParameters.getPadding()),
-					dimensionAndPosition.getTextY()
-							+ textSizeWithDpi(textParameters.getPadding()),
+					dimensionAndPosition.getTextX(), dimensionAndPosition.getTextY(),
 					dimensionAndPosition.getTextWidth(), dimensionAndPosition.getTextHeight());
 			setBackground(cs, textParameters.getBackgroundColor(), rect);
 		}
-	}
-
-	private float textSizeWithDpi(float size) {
-		return CommonDrawerUtils.toDpiAxisPoint(size, parameters.getDpi());
 	}
 
 	/**

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
@@ -21,7 +21,6 @@
 package eu.europa.esig.dss.pdf.pdfbox.visible.nativedrawer;
 
 import eu.europa.esig.dss.pdf.AnnotationBox;
-import eu.europa.esig.dss.pdf.visible.CommonDrawerUtils;
 import eu.europa.esig.dss.pdf.visible.VisualSignatureFieldAppearance;
 
 public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldAppearance {
@@ -145,13 +144,6 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 
 	public void setGlobalRotation(int globalRotation) {
 		this.globalRotation = globalRotation;
-	}
-	
-	public void paddingShift(float padding, Integer imageDpi) {
-		float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(padding, imageDpi);
-		this.textX += scaledPadding;
-		// minus, because PDF starts to count from bottom
-		this.textY -= scaledPadding;
 	}
 
 	@Override

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPosition.java
@@ -40,6 +40,11 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 	private float textWidth = 0;
 	private float textHeight = 0;
 	
+	private float textBoxX = 0;
+	private float textBoxY = 0;
+	private float textBoxWidth = 0;
+	private float textBoxHeight = 0;
+	
 	private int globalRotation;
 
 	public float getBoxX() {
@@ -136,6 +141,38 @@ public class SignatureFieldDimensionAndPosition implements VisualSignatureFieldA
 	
 	public void setTextHeight(float textHeight) {
 		this.textHeight = textHeight;
+	}
+
+	public float getTextBoxX() {
+		return textBoxX;
+	}
+	
+	public void setTextBoxX(float textBoxX) {
+		this.textBoxX = textBoxX;
+	}
+	
+	public float getTextBoxY() {
+		return textBoxY;
+	}
+	
+	public void setTextBoxY(float textBoxY) {
+		this.textBoxY = textBoxY;
+	}
+	
+	public float getTextBoxWidth() {
+		return textBoxWidth;
+	}
+	
+	public void setTextBoxWidth(float textBoxWidth) {
+		this.textBoxWidth = textBoxWidth;
+	}
+	
+	public float getTextBoxHeight() {
+		return textBoxHeight;
+	}
+	
+	public void setTextBoxHeight(float textBoxHeight) {
+		this.textBoxHeight = textBoxHeight;
 	}
 
 	public int getGlobalRotation() {

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
@@ -199,8 +199,6 @@ public class SignatureFieldDimensionAndPositionBuilder {
 
 			dimensionAndPosition.setTextWidth(textWidth);
 			dimensionAndPosition.setTextHeight(textHeight);
-			Integer imageDpi = imageParameters.getImage() != null ? imageParameters.getDpi() : DEFAULT_DPI;
-			dimensionAndPosition.paddingShift(textParameters.getPadding(), imageDpi);
 		}
 
 		int rotation = ImageRotationUtils.getRotation(imageParameters.getRotation(), page);

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/SignatureFieldDimensionAndPositionBuilder.java
@@ -139,8 +139,9 @@ public class SignatureFieldDimensionAndPositionBuilder {
 		// if text is present
 		if (!textParameters.isEmpty()) {
 
+			float scaledPadding = CommonDrawerUtils.toDpiAxisPoint(textParameters.getPadding(), imageParameters.getDpi());
 			// native implementation uses dpi-independent font
-			AnnotationBox textBox = computeTextDimension(textParameters);
+			AnnotationBox textBox = computeTextDimension(textParameters, scaledPadding);
 			float textWidth = textBox.getWidth();
 			float textHeight = textBox.getHeight();
 
@@ -166,7 +167,7 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				if (fieldParameters.getHeight() == 0) {
 					height = Math.max(height, textHeight);
 				}
-				dimensionAndPosition.setTextX(width - textWidth);
+				dimensionAndPosition.setTextBoxX(width - textWidth);
 				textImageVerticalAlignment(height, imageHeight, textHeight);
 				break;
 			case TOP:
@@ -178,7 +179,7 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				} else {
 					imageHeight -= imageParameters.getImage() != null || height == 0 ? textHeight : 0;
 				}
-				dimensionAndPosition.setTextY(height - textHeight);
+				dimensionAndPosition.setTextBoxY(height - textHeight);
 				textImageHorizontalAlignment(width, imageWidth, textWidth);
 				break;
 			case BOTTOM:
@@ -197,8 +198,13 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				break;
 			}
 
-			dimensionAndPosition.setTextWidth(textWidth);
-			dimensionAndPosition.setTextHeight(textHeight);
+			dimensionAndPosition.setTextBoxWidth(textWidth);
+			dimensionAndPosition.setTextBoxHeight(textHeight);
+
+			dimensionAndPosition.setTextX(dimensionAndPosition.getTextBoxX() + scaledPadding);
+			dimensionAndPosition.setTextY(dimensionAndPosition.getTextBoxY() + scaledPadding);
+			dimensionAndPosition.setTextWidth(dimensionAndPosition.getTextBoxWidth() - 2 * scaledPadding);
+			dimensionAndPosition.setTextHeight(dimensionAndPosition.getTextBoxHeight() - 2 * scaledPadding);
 		}
 
 		int rotation = ImageRotationUtils.getRotation(imageParameters.getRotation(), page);
@@ -217,13 +223,13 @@ public class SignatureFieldDimensionAndPositionBuilder {
 		dimensionAndPosition.setBoxHeight(height);
 	}
 
-	private AnnotationBox computeTextDimension(SignatureImageTextParameters textParameters) {
+	private AnnotationBox computeTextDimension(SignatureImageTextParameters textParameters, float scaledPadding) {
 		float properSize = textParameters.getFont().getSize()
 				* ImageUtils.getScaleFactor(imageParameters.getZoom()); // scale text block
 
 		PdfBoxFontMetrics pdfBoxFontMetrics = new PdfBoxFontMetrics(pdFont);
 		return pdfBoxFontMetrics.computeTextBoundaryBox(textParameters.getText(), properSize,
-				CommonDrawerUtils.toDpiAxisPoint(textParameters.getPadding(), imageParameters.getDpi()));
+				scaledPadding);
 	}
 
 	private void textImageVerticalAlignment(float height, float imageHeight, float textHeight) {
@@ -231,15 +237,15 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				.getSignerTextVerticalAlignment();
 		switch (verticalAlignment) {
 		case TOP:
-			dimensionAndPosition.setTextY(height - textHeight);
+			dimensionAndPosition.setTextBoxY(height - textHeight);
 			dimensionAndPosition.setImageY(height - imageHeight);
 			break;
 		case BOTTOM:
-			dimensionAndPosition.setTextY(0);
+			dimensionAndPosition.setTextBoxY(0);
 			dimensionAndPosition.setImageY(0);
 			break;
 		case MIDDLE:
-			dimensionAndPosition.setTextY((height - textHeight) / 2);
+			dimensionAndPosition.setTextBoxY((height - textHeight) / 2);
 			dimensionAndPosition.setImageY((height - imageHeight) / 2);
 			break;
 		default:
@@ -252,15 +258,15 @@ public class SignatureFieldDimensionAndPositionBuilder {
 				.getSignerTextHorizontalAlignment();
 		switch (horizontalAlignment) {
 		case LEFT:
-			dimensionAndPosition.setTextX(0);
+			dimensionAndPosition.setTextBoxX(0);
 			dimensionAndPosition.setImageX(0);
 			break;
 		case RIGHT:
-			dimensionAndPosition.setTextX(width - textWidth);
+			dimensionAndPosition.setTextBoxX(width - textWidth);
 			dimensionAndPosition.setImageX(width - imageWidth);
 			break;
 		case CENTER:
-			dimensionAndPosition.setTextX((width - textWidth) / 2);
+			dimensionAndPosition.setTextBoxX((width - textWidth) / 2);
 			dimensionAndPosition.setImageX((width - imageWidth) / 2);
 			break;
 		default:


### PR DESCRIPTION
Encapsulates the  padding calculations of the native PDFBox drawer in `SignatureFieldDimensionAndPositionBuilder` to reduce repetition and to make the code easier to understand.

More details in JIRA ticket [DSS-2458](https://ec.europa.eu/cefdigital/tracker/browse/DSS-2458).