### PR TITLE
Correct default timeout

### DIFF
--- a/dss-service/src/main/java/eu/europa/esig/dss/service/http/commons/CommonsDataLoader.java
+++ b/dss-service/src/main/java/eu/europa/esig/dss/service/http/commons/CommonsDataLoader.java
@@ -111,10 +111,10 @@ public class CommonsDataLoader implements DataLoader {
 	private static final Logger LOG = LoggerFactory.getLogger(CommonsDataLoader.class);
 
 	/** The default connection timeout (1 minute) */
-	private static final int TIMEOUT_CONNECTION = 6000;
+	private static final int TIMEOUT_CONNECTION = 60000;
 
 	/** The default socket timeout (1 minute) */
-	private static final int TIMEOUT_SOCKET = 6000;
+	private static final int TIMEOUT_SOCKET = 60000;
 
 	/** The default value of maximum connections in time (20) */
 	private static final int CONNECTIONS_MAX_TOTAL = 20;


### PR DESCRIPTION
This breaks our app today.
 We have a failover proxy for multiple TSA sources.
 And we happen to need its functionalities today. However, DSS won't wait for our proxy.

I think the default value is incorrect. At least what was written and the actual behavior does not match.