### PR TITLE
DSS-2571: Make NativePdfBoxVisibleSignatureDrawer PDFA compabible

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
@@ -96,7 +96,7 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 		} else if (dssFont instanceof DSSFileFont) {
 			DSSFileFont fileFont = (DSSFileFont) dssFont;
 			try (InputStream is = fileFont.getInputStream()) {
-				return PDType0Font.load(document, is);
+				return PDType0Font.load(document, is, false);
 			}
 		} else {
 			return PdfBoxFontMapper.getPDFont(dssFont.getJavaFont());


### PR DESCRIPTION
Motivation
In DSS 5.9, by default, the font loaded by the NativePdfBoxVisibleSignatureDrawer break PDFA-3 rules