### PR TITLE
support PDF files ending with `\r%%EOF` as well as those ending with `\n%%EOF`

### DIFF
--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/PAdESUtils.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/PAdESUtils.java
@@ -152,7 +152,7 @@ public final class PAdESUtils {
 					baos.write(tempRevision.toByteArray());
 					tempRevision.close();
 					tempRevision = new ByteArrayOutputStream();
-				} else if (b == 0x0a || stringBytes.length > eof.length) {
+				} else if (b == 0x0a || b == 0x0d || stringBytes.length > eof.length) {
 					tempRevision.write(tempLine.toByteArray());
 					tempLine.close();
 					tempLine = new ByteArrayOutputStream();


### PR DESCRIPTION
DSS library especially this function `PDFDocumentValidator.getOriginalDocuments()`Expects the final Bytes to be `\n%%EOF` but when the original document ends with `\r%%EOF` we get an error.

Here I added this code '|| b == 0x0d' in order to fix the above error.

in attachments you'll find two example files:
[test 35.pdf](https://github.com/esig/dss/files/7331145/test.35.pdf)
[test 36.pdf](https://github.com/esig/dss/files/7331146/test.36.pdf)
