### PR TITLE
PAdES: signing app name for pades signatures

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -65,6 +65,8 @@ import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDPropBuild;
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDPropBuildDataDict;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureInterface;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureOptions;
@@ -361,6 +363,17 @@ public class PdfBoxSignatureService extends AbstractPDFSignatureService {
 
 			if (Utils.isStringNotEmpty(signatureParameters.getLocation())) {
 				signature.setLocation(signatureParameters.getLocation());
+			}
+
+			if (Utils.isStringNotEmpty(signatureParameters.getAppName())) {
+				PDPropBuild propBuild = signature.getPropBuild();
+				if (propBuild == null) {
+					propBuild = new PDPropBuild(new COSDictionary());
+				}
+				PDPropBuildDataDict app = new PDPropBuildDataDict();
+				app.setName(signatureParameters.getAppName());
+				propBuild.setPDPropBuildApp(app);
+				signature.setPropBuild(propBuild);
 			}
 
 			if (Utils.isStringNotEmpty(signatureParameters.getReason())) {

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/PAdESSignatureParameters.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/PAdESSignatureParameters.java
@@ -46,6 +46,9 @@ public class PAdESSignatureParameters extends CAdESSignatureParameters implement
 	/** The signer's location */
 	private String location;
 
+	/** The signing app name */
+	private String appName;
+
 	/**
 	 * Defines the preserved space for a signature context
 	 *
@@ -221,6 +224,24 @@ public class PAdESSignatureParameters extends CAdESSignatureParameters implement
 	 */
 	public void setLocation(String location) {
 		this.location = location;
+	}
+
+	/**
+	 * Gets signing application name
+	 *
+	 * @return {@link String}
+	 */
+	public String getAppName() {
+		return appName;
+	}
+
+	/**
+	 * Sets signing application name
+	 *
+	 * @param appName {@link String}
+	 */
+	public void setAppName(String appName) {
+		this.appName = appName;
 	}
 
 	@Override

--- a/dss-pades/src/test/java/eu/europa/esig/dss/pades/signature/visible/suite/PAdESLevelBCertificationTest.java
+++ b/dss-pades/src/test/java/eu/europa/esig/dss/pades/signature/visible/suite/PAdESLevelBCertificationTest.java
@@ -61,6 +61,7 @@ public class PAdESLevelBCertificationTest extends AbstractPAdESTestSignature {
 		signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
 		signatureParameters.setLocation("Luxembourg");
 		signatureParameters.setReason("DSS testing");
+		signatureParameters.setAppName("DSS lib");
 		signatureParameters.setContactInfo("Jira");
 		signatureParameters.setPermission(CertificationPermission.MINIMAL_CHANGES_PERMITTED);
 		SignatureImageParameters signatureImageParameters = new SignatureImageParameters();


### PR DESCRIPTION
By a PDF specification It is able to add a signing application name into Sig dictionary.
https://www.pdfa.org/norm-refs/SigBuildDict.pdf

This PR adds simple support for adding signing app name into pades signature.
Unfortunately ONLY pdfbox supports methods to add this property out of the box.
OpenPdf does not support it (requires additional support on their side).

reported as a new feature request
https://ec.europa.eu/cefdigital/tracker/browse/DSS-2692