### PR TITLE
Simplified "toString" to avoid synchronization

### DIFF
--- a/dss-model/src/main/java/eu/europa/esig/dss/model/CommonDocument.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/model/CommonDocument.java
@@ -123,10 +123,9 @@ public abstract class CommonDocument implements DSSDocument {
 
 	@Override
 	public String toString() {
-		final StringWriter stringWriter = new StringWriter();
-		stringWriter.append("Name: ").append(getName()).append(" / MimeType: ")
-				.append(mimeType == null ? "" : mimeType.getMimeTypeString());
-		return stringWriter.toString();
+		final String mimeTypeString = (mimeType == null) ? "" : mimeType.getMimeTypeString();
+		final String name = getName();
+		return "Name: " + name + " / MimeType: " + mimeTypeString;
 	}
 
 }


### PR DESCRIPTION
`StringWriter` internally uses a `StringBuffer`, which uses synchronization over an internal object.
In this case the synchronization is not necessary, and a simpler string composition is more efficient and effective. 
Furthermore, composing the result with a `StringWriter` prevents the compiler to use the `String` composition based on the `invokedynamic` implementation, that generate the `CallSite` only if necessary, and mask the fact that the final length can be calculated at creation, thus avoiding resizings and relocations.