### PR TITLE
DSS-2930 Decrease memory usage by returning byte array of raw streams

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxArray.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxArray.java
@@ -93,7 +93,7 @@ class PdfBoxArray implements PdfArray {
 		if (cosStream == null) {
 			throw new DSSException("Cannot find value for " + val + " of class " + val.getClass());
 		}
-		try (InputStream is = cosStream.createInputStream()) {
+		try (InputStream is = cosStream.createRawInputStream()) {
 			return DSSUtils.toByteArray(is);
 		}
 	}

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxDict.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxDict.java
@@ -191,7 +191,7 @@ class PdfBoxDict implements PdfDict {
 	@Override
 	public byte[] getStreamBytes() throws IOException {
 		if (wrapped instanceof COSStream) {
-			try (InputStream is = ((COSStream) wrapped).createInputStream()) {
+			try (InputStream is = ((COSStream) wrapped).createRawInputStream()) {
 				return Utils.toByteArray(is);
 			}
 		}


### PR DESCRIPTION
Replace `createInputStream()` with `createRawInputStream()` when returning a byte array for a COS stream in `PdfBoxDict` and `PdfBoxArray` to avoid excessive memory usage.

Using `createInputStream()` creates internally a object presentation of the content of a stream, e.g. an image will be rendered into memory, and then returns the byte array of  the rendered representation. The byte length of the rendered representation can be of a magnitude bigger than the byte length of the raw stream, hence using `createRawInputStream()` greatly decreases memory usage.

This PR greatly improves the situation described in https://ec.europa.eu/digital-building-blocks/tracker/browse/DSS-2930
We've looked especially at  `DefaultPdfObjectModificationsFinder`, which compares the byte arrays of streams for equality (https://github.com/esig/dss/blob/master/dss-pades/src/main/java/eu/europa/esig/dss/pdf/modifications/DefaultPdfObjectModificationsFinder.java#L282) . We used a PDF document with a high resolution image of about 7Mb. The byte array length when using `createRawInputStream()` is still about 7Mb, whereas the byte array length when using  `createInputStream()` was 1.3Gb.

Please note that I haven't explicitly tested the replacement in `PdfBoxArray` which is used in `DSSDictionaryExtractionUtils` 
 (https://github.com/esig/dss/blob/master/dss-pades/src/main/java/eu/europa/esig/dss/pdf/DSSDictionaryExtractionUtils.java), it should be fine, but let me know if that commit should be dropped. 