### PR TITLE
Upgrade default SSL protocol to TLSv1.3

### DIFF
--- a/dss-service/src/main/java/eu/europa/esig/dss/service/http/commons/CommonsDataLoader.java
+++ b/dss-service/src/main/java/eu/europa/esig/dss/service/http/commons/CommonsDataLoader.java
@@ -125,7 +125,7 @@ public class CommonsDataLoader implements DataLoader {
 	private static final String CONTENT_TYPE = "Content-Type";
 
 	/** The default SSL protocol */
-	private static final String DEFAULT_SSL_PROTOCOL = "TLSv1.2";
+	private static final String DEFAULT_SSL_PROTOCOL = "TLSv1.3";
 
 	/** The list of accepted statuses for a successful connection */
 	private static final List<Integer> ACCEPTED_HTTP_STATUS = Collections.singletonList(HttpStatus.SC_OK);
@@ -507,7 +507,7 @@ public class CommonsDataLoader implements DataLoader {
 	}
 
 	/**
-	 * This method sets the SSL protocol to be used ('TLSv1.2' by default)
+	 * This method sets the SSL protocol to be used ('TLSv1.3' by default)
 	 *
 	 * @param sslProtocol
 	 *                    the ssl protocol to be used


### PR DESCRIPTION
Hy,

The french trusted list https://ssi.gouv.fr/uploads/tl-fr.xml present in eu lotl : https://ec.europa.eu/tools/lotl/eu-lotl.xml use TLSv1.3.

Actually I use a specific setting in my dataloader Bean : 

```
	@Bean
	public CommonsDataLoader dataLoader() {
		CommonsDataLoader dataLoader = configureCommonsDataLoader(new CommonsDataLoader());
		dataLoader.setProxyConfig(proxyConfig);
		dataLoader.setSslProtocol("TLSv1.3");
		return dataLoader;
	}
```

All other EU trusted list work well with TLSv1.3. Is it a good idea to set TLSv1.3 as default ssl protocol ?

Regards,
