### PR TITLE
more flexible proxy configuration

### DIFF
--- a/dss-service/src/main/java/eu/europa/esig/dss/service/http/commons/CommonsDataLoader.java
+++ b/dss-service/src/main/java/eu/europa/esig/dss/service/http/commons/CommonsDataLoader.java
@@ -1438,12 +1438,20 @@ public class CommonsDataLoader implements DataLoader {
 
 				@Override
 				protected HttpHost determineProxy(HttpHost host, HttpContext context) throws HttpException {
-					String hostname = (host != null ? host.getHostName() : null);
+					String hostname = (host != null ? host.getHostName().toLowerCase() : null);
 					if (hostname != null) {
 						for (String h : excludedHosts) {
-							if (Utils.areStringsEqualIgnoreCase(hostname, h)) {
+							String hostnamePattern = h.toLowerCase();
+							if (hostname.equals(hostnamePattern)) {
 								// bypass proxy for that hostname
 								return null;
+							}
+							if (hostnamePattern.startsWith("*")) {
+								String matchingEnd = hostnamePattern.substring(1).toLowerCase();
+								if( hostname.endsWith(matchingEnd)) {
+									// pattern matches, bypass proxy for that hostname
+									return null;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
In big organisations it's impossible to add all intranet server with their name to the proxy exlude list.
This PR implements a more flexible proxy configuration, allowing a leading wildcard in excludes.