### PR TITLE
DSS-3070 Pkcs11SignatureToken - Provider was not cleaned-up correctly

### DIFF
--- a/dss-token/src/main/java/eu/europa/esig/dss/token/Pkcs11SignatureToken.java
+++ b/dss-token/src/main/java/eu/europa/esig/dss/token/Pkcs11SignatureToken.java
@@ -367,11 +367,11 @@ public class Pkcs11SignatureToken extends AbstractKeyStoreTokenConnection {
 				try {
 					if (provider instanceof AuthProvider) {
 						((AuthProvider) provider).logout();
-						provider.clear();
 					}
 				} catch (LoginException e) {
 					LOG.error("Unable to logout : {}", e.getMessage(), e);
 				}
+				provider.clear();
 				Security.removeProvider(provider.getName());
 			} catch (SecurityException e) {
 				LOG.error("Unable to remove provider '{}'", provider.getName(), e);


### PR DESCRIPTION
Fix for: https://ec.europa.eu/digital-building-blocks/tracker/browse/DSS-3070