### PR TITLE
DSS-3207: added memory setting usage parameter @ dss-pades-pdfbox

### DIFF
--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxDefaultObjectFactory.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxDefaultObjectFactory.java
@@ -20,6 +20,8 @@
  */
 package eu.europa.esig.dss.pdf.pdfbox;
 
+import org.apache.pdfbox.io.MemoryUsageSetting;
+
 import eu.europa.esig.dss.pdf.AbstractPdfObjFactory;
 import eu.europa.esig.dss.pdf.PDFServiceMode;
 import eu.europa.esig.dss.pdf.PDFSignatureService;
@@ -31,6 +33,17 @@ import eu.europa.esig.dss.pdf.pdfbox.visible.defaultdrawer.PdfBoxDefaultSignatur
  */
 public class PdfBoxDefaultObjectFactory extends AbstractPdfObjFactory {
 
+	private MemoryUsageSetting memoryUsageSetting = MemoryUsageSetting.setupMainMemoryOnly();
+
+	public MemoryUsageSetting getMemoryUsageSetting() {
+		return memoryUsageSetting;
+	}
+
+	public void setMemoryUsageSetting(MemoryUsageSetting memoryUsageSetting) {
+		this.memoryUsageSetting = memoryUsageSetting;
+	}
+	
+	
 	/**
 	 * Default constructor
 	 */
@@ -40,22 +53,22 @@ public class PdfBoxDefaultObjectFactory extends AbstractPdfObjFactory {
 
 	@Override
 	public PDFSignatureService newPAdESSignatureService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE, new PdfBoxDefaultSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE, new PdfBoxDefaultSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 	@Override
 	public PDFSignatureService newContentTimestampService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.CONTENT_TIMESTAMP, new PdfBoxDefaultSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.CONTENT_TIMESTAMP, new PdfBoxDefaultSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 	@Override
 	public PDFSignatureService newSignatureTimestampService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE_TIMESTAMP, new PdfBoxDefaultSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE_TIMESTAMP, new PdfBoxDefaultSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 	@Override
 	public PDFSignatureService newArchiveTimestampService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.ARCHIVE_TIMESTAMP, new PdfBoxDefaultSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.ARCHIVE_TIMESTAMP, new PdfBoxDefaultSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 }

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxNativeObjectFactory.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxNativeObjectFactory.java
@@ -20,6 +20,8 @@
  */
 package eu.europa.esig.dss.pdf.pdfbox;
 
+import org.apache.pdfbox.io.MemoryUsageSetting;
+
 import eu.europa.esig.dss.pdf.AbstractPdfObjFactory;
 import eu.europa.esig.dss.pdf.PDFServiceMode;
 import eu.europa.esig.dss.pdf.PDFSignatureService;
@@ -31,6 +33,16 @@ import eu.europa.esig.dss.pdf.pdfbox.visible.nativedrawer.PdfBoxNativeSignatureD
  */
 public class PdfBoxNativeObjectFactory extends AbstractPdfObjFactory {
 
+	private MemoryUsageSetting memoryUsageSetting = MemoryUsageSetting.setupMainMemoryOnly();
+
+	public MemoryUsageSetting getMemoryUsageSetting() {
+		return memoryUsageSetting;
+	}
+
+	public void setMemoryUsageSetting(MemoryUsageSetting memoryUsageSetting) {
+		this.memoryUsageSetting = memoryUsageSetting;
+	}
+	
 	/**
 	 * Default constructor
 	 */
@@ -40,22 +52,22 @@ public class PdfBoxNativeObjectFactory extends AbstractPdfObjFactory {
 
 	@Override
 	public PDFSignatureService newPAdESSignatureService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE, new PdfBoxNativeSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE, new PdfBoxNativeSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 	@Override
 	public PDFSignatureService newContentTimestampService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.CONTENT_TIMESTAMP, new PdfBoxNativeSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.CONTENT_TIMESTAMP, new PdfBoxNativeSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 	@Override
 	public PDFSignatureService newSignatureTimestampService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE_TIMESTAMP, new PdfBoxNativeSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.SIGNATURE_TIMESTAMP, new PdfBoxNativeSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 	@Override
 	public PDFSignatureService newArchiveTimestampService() {
-		return configure(new PdfBoxSignatureService(PDFServiceMode.ARCHIVE_TIMESTAMP, new PdfBoxNativeSignatureDrawerFactory()));
+		return configure(new PdfBoxSignatureService(PDFServiceMode.ARCHIVE_TIMESTAMP, new PdfBoxNativeSignatureDrawerFactory(), memoryUsageSetting));
 	}
 
 }

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxUtils.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxUtils.java
@@ -25,6 +25,8 @@ import eu.europa.esig.dss.model.DSSException;
 import eu.europa.esig.dss.pades.PAdESUtils;
 import eu.europa.esig.dss.pdf.visible.ImageUtils;
 import eu.europa.esig.dss.signature.resources.DSSResourcesHandler;
+
+import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
@@ -141,7 +143,7 @@ public class PdfBoxUtils {
 																int page) {
 		Objects.requireNonNull(pdfDocument, "pdfDocument shall be defined!");
 		try (PdfBoxDocumentReader reader = new PdfBoxDocumentReader(
-				pdfDocument, passwordProtection != null ? new String(passwordProtection) : null)) {
+				pdfDocument, passwordProtection != null ? new String(passwordProtection) : null, MemoryUsageSetting.setupMainMemoryOnly())) {
 			return reader.generateImageScreenshot(page);
 		} catch (IOException e) {
 			throw new DSSException(String.format("Unable to generate a screenshot for the document with name '%s' "

--- a/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxDocumentReaderTest.java
+++ b/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxDocumentReaderTest.java
@@ -26,6 +26,8 @@ import eu.europa.esig.dss.pades.PAdESSignatureParameters;
 import eu.europa.esig.dss.pdf.PdfDocumentReader;
 import eu.europa.esig.dss.pdf.PdfDssDict;
 import eu.europa.esig.dss.test.PKIFactoryAccess;
+
+import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.junit.jupiter.api.Test;
@@ -87,7 +89,7 @@ class PdfBoxDocumentReaderTest extends PKIFactoryAccess {
 	@Test
 	void permissionsProtectedDocument() throws IOException {
 		DSSDocument dssDocument = new InMemoryDocument(getClass().getResourceAsStream("/protected/open_protected.pdf"));
-		try (PdfBoxDocumentReader documentReader = new PdfBoxDocumentReader(dssDocument, " ")) {
+		try (PdfBoxDocumentReader documentReader = new PdfBoxDocumentReader(dssDocument, " ", MemoryUsageSetting.setupMainMemoryOnly())) {
 			assertTrue(documentReader.isEncrypted());
 			assertTrue(documentReader.isOpenWithOwnerAccess());
 			assertTrue(documentReader.canFillSignatureForm());
@@ -98,7 +100,7 @@ class PdfBoxDocumentReaderTest extends PKIFactoryAccess {
 	@Test
 	void permissionsEditionProtectedDocument() throws IOException {
 		DSSDocument dssDocument = new InMemoryDocument(getClass().getResourceAsStream("/protected/edition_protected_none.pdf"));
-		try (PdfBoxDocumentReader documentReader = new PdfBoxDocumentReader(dssDocument, " ")) {
+		try (PdfBoxDocumentReader documentReader = new PdfBoxDocumentReader(dssDocument, " ", MemoryUsageSetting.setupMainMemoryOnly())) {
 			assertTrue(documentReader.isEncrypted());
 			assertTrue(documentReader.isOpenWithOwnerAccess());
 			assertTrue(documentReader.canFillSignatureForm());
@@ -109,7 +111,7 @@ class PdfBoxDocumentReaderTest extends PKIFactoryAccess {
 	@Test
 	void permissionsEditionNoFieldsProtectedDocument() throws IOException {
 		DSSDocument dssDocument = new InMemoryDocument(getClass().getResourceAsStream("/protected/edition_protected_signing_allowed_no_field.pdf"));
-		try (PdfBoxDocumentReader documentReader = new PdfBoxDocumentReader(dssDocument, " ")) {
+		try (PdfBoxDocumentReader documentReader = new PdfBoxDocumentReader(dssDocument, " ", MemoryUsageSetting.setupMainMemoryOnly())) {
 			assertTrue(documentReader.isEncrypted());
 			assertTrue(documentReader.isOpenWithOwnerAccess());
 			assertTrue(documentReader.canFillSignatureForm());


### PR DESCRIPTION
@bsanchezb I have added the memory setting for pdfbox as we discussed in https://ec.europa.eu/digital-building-blocks/tracker/browse/DSS-3207

I need some guidances for:
1. formatting correctly the code, which formatter should be used?
2. how have memory settings-like aspect been managed so far in the unit tests? Which unit tests should I write so that would be valuable?

Manually, in order to confirm the activity, I locally wrote:
![immagine](https://github.com/user-attachments/assets/b47d3aa9-95d1-486c-9fe0-ede90b3b79fc)
and checked with _temp file only_ and _memory only_ in debug mode with breakpoints meanwhile monitoring the heap usage with visualvm and triggering gc at each stage.

Memory-only:
![Pades Signature - Memory Only- 2 350 MB files](https://github.com/user-attachments/assets/122c8b17-e876-4174-93ff-a5c6ae90fa37)

Temp file only:
![Pades Signature - TempFile Only- 2 350 MB files](https://github.com/user-attachments/assets/62b036e6-eb72-4ea5-9841-eef2cf94c265)

The improvement at best around 50% less heap usage, in PDFBox version 3 it should further improve: https://pdfbox.apache.org/3.0/migration.html#reduced-memory-usage
3. I haven't made changes for openpdf, the settings would be slightly different since the library handles the aspect in a different way. Let me know if it is valuable to do it.
4. I haven't written any javadoc or documentation, can you guide me on that?