### PR TITLE
Add multi-widget support for PAdES visible signatures (PDFBox)

### DIFF
--- a/dss-cookbook/src/main/asciidoc/_chapters/annex.adoc
+++ b/dss-cookbook/src/main/asciidoc/_chapters/annex.adoc
@@ -227,6 +227,19 @@ DSS framework provides a set of functions to manage the signature field size :
 include::{sourcetestdir}/eu/europa/esig/dss/cookbook/example/snippets/PAdESVisibleSignatureSnippet.java[tags=dimensions]
 ----
 
+[[MultipleWidgets]]
+====== Multiple widgets (multi-widget signature)
+
+DSS allows a single PAdES signature to be displayed in several positions and/or pages at once, through multiple widgets sharing the same signature field (i.e. a single signature value and a single `/ByteRange`). In addition to the primary field, additional fields can be defined; every additional widget shares the same visual appearance (image, text, ...) as the primary field and differs only in its position, dimensions, page and rotation.
+
+NOTE: multi-widget signatures are currently supported by the PDFBox implementation only. The OpenPDF implementation throws an `UnsupportedOperationException` when additional fields are defined.
+
+[source,java,indent=0]
+.Multi-widget signature (the same signature shown in several positions/pages)
+----
+include::{sourcetestdir}/eu/europa/esig/dss/cookbook/example/snippets/PAdESVisibleSignatureSnippet.java[tags=multiWidget]
+----
+
 [[TextParameters]]
 ====== Text Parameters
 

--- a/dss-cookbook/src/test/java/eu/europa/esig/dss/cookbook/example/snippets/PAdESVisibleSignatureSnippet.java
+++ b/dss-cookbook/src/test/java/eu/europa/esig/dss/cookbook/example/snippets/PAdESVisibleSignatureSnippet.java
@@ -139,6 +139,40 @@ public class PAdESVisibleSignatureSnippet {
 		
 	}
 
+	public void multipleWidgets() {
+
+		// tag::multiWidget[]
+		// import eu.europa.esig.dss.pades.SignatureImageParameters;
+		// import eu.europa.esig.dss.pades.SignatureFieldParameters;
+
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		// ... define the visual appearance (image and/or text) as usual ...
+
+		// The primary field defines the first widget (position, dimensions, page and rotation).
+		SignatureFieldParameters primaryField = new SignatureFieldParameters();
+		primaryField.setPage(1);
+		primaryField.setOriginX(50);
+		primaryField.setOriginY(50);
+		primaryField.setWidth(100);
+		primaryField.setHeight(50);
+		imageParameters.setFieldParameters(primaryField);
+
+		// Additional fields make the SAME signature (a single signature value) appear in other
+		// positions and/or pages, through several widgets. Each additional widget shares the same
+		// visual appearance (image, text, ...) as the primary field and differs only in its position,
+		// dimensions, page and rotation.
+		// NOTE: multi-widget signatures are currently supported by the PDFBox implementation only.
+		SignatureFieldParameters secondWidget = new SignatureFieldParameters();
+		secondWidget.setPage(2);
+		secondWidget.setOriginX(50);
+		secondWidget.setOriginY(50);
+		secondWidget.setWidth(100);
+		secondWidget.setHeight(50);
+		imageParameters.addFieldParameters(secondWidget);
+
+		// end::multiWidget[]
+	}
+
 	public void dss65Migration() {
 		DSSDocument modifiedImage = new InMemoryDocument(); // blank sample
 

--- a/dss-pades-openpdf/src/main/java/eu/europa/esig/dss/pdf/openpdf/ITextPDFSignatureService.java
+++ b/dss-pades-openpdf/src/main/java/eu/europa/esig/dss/pdf/openpdf/ITextPDFSignatureService.java
@@ -126,6 +126,11 @@ public class ITextPDFSignatureService extends AbstractPDFSignatureService {
 		sap.setAcro6Layers(true);
 
 		SignatureImageParameters imageParameters = parameters.getImageParameters();
+		if (!imageParameters.getAdditionalFieldParameters().isEmpty()) {
+			throw new UnsupportedOperationException(
+					"Multi-widget signatures (additional signature field widgets) are not supported by the OpenPDF "
+							+ "implementation. Please use the PDFBox implementation instead.");
+		}
 		SignatureFieldParameters fieldParameters = imageParameters.getFieldParameters();
 
 		Item fieldItem = findExistingSignatureField(reader, fieldParameters);

--- a/dss-pades-openpdf/src/main/java/eu/europa/esig/dss/pdf/openpdf/ITextPDFSignatureService.java
+++ b/dss-pades-openpdf/src/main/java/eu/europa/esig/dss/pdf/openpdf/ITextPDFSignatureService.java
@@ -127,6 +127,12 @@ public class ITextPDFSignatureService extends AbstractPDFSignatureService {
 
 		SignatureImageParameters imageParameters = parameters.getImageParameters();
 		if (!imageParameters.getAdditionalFieldParameters().isEmpty()) {
+			// Multi-widget signatures are not supported by the OpenPDF implementation. OpenPDF's
+			// PdfSignatureAppearance creates the signature field and its single widget inside preClose(), and
+			// the signed /ByteRange is fixed at that point, so additional widgets (/Kids) cannot be attached to
+			// the field within the single-pass signing flow. A future implementation would require a different,
+			// two-revision approach (create the empty multi-widget field, then sign it). Use the PDFBox
+			// implementation, which fully supports multi-widget signatures.
 			throw new UnsupportedOperationException(
 					"Multi-widget signatures (additional signature field widgets) are not supported by the OpenPDF "
 							+ "implementation. Please use the PDFBox implementation instead.");

--- a/dss-pades-openpdf/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetOpenPdfUnsupportedTest.java
+++ b/dss-pades-openpdf/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetOpenPdfUnsupportedTest.java
@@ -1,0 +1,97 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * <p>
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * <p>
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * <p>
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.pades.signature.visible;
+
+import eu.europa.esig.dss.enumerations.MimeTypeEnum;
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.InMemoryDocument;
+import eu.europa.esig.dss.pades.PAdESSignatureParameters;
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
+import eu.europa.esig.dss.pades.SignatureImageParameters;
+import eu.europa.esig.dss.pades.signature.PAdESService;
+import eu.europa.esig.dss.pdf.openpdf.ITextDefaultPdfObjFactory;
+import eu.europa.esig.dss.test.PKIFactoryAccess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Multi-widget signatures are not supported by the OpenPDF implementation. This test verifies that a clear
+ * {@code UnsupportedOperationException} is raised when additional signature field widgets are requested.
+ */
+class PAdESMultiWidgetOpenPdfUnsupportedTest extends PKIFactoryAccess {
+
+	private PAdESService service;
+	private PAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+
+	@BeforeEach
+	void init() {
+		documentToSign = new InMemoryDocument(getClass().getResourceAsStream("/sample.pdf"));
+
+		signatureParameters = new PAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
+
+		service = new PAdESService(getCompleteCertificateVerifier());
+		service.setPdfObjFactory(new ITextDefaultPdfObjFactory());
+
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(new InMemoryDocument(getClass().getResourceAsStream("/small-red.jpg"), "small-red.jpg", MimeTypeEnum.JPEG));
+
+		SignatureFieldParameters primary = new SignatureFieldParameters();
+		primary.setOriginX(50);
+		primary.setOriginY(50);
+		primary.setWidth(100);
+		primary.setHeight(50);
+		imageParameters.setFieldParameters(primary);
+
+		SignatureFieldParameters additional = new SignatureFieldParameters();
+		additional.setOriginX(50);
+		additional.setOriginY(200);
+		additional.setWidth(100);
+		additional.setHeight(50);
+		imageParameters.setAdditionalFieldParameters(Collections.singletonList(additional));
+
+		signatureParameters.setImageParameters(imageParameters);
+	}
+
+	@Test
+	void additionalWidgetsUnsupportedTest() {
+		Exception exception = assertThrows(UnsupportedOperationException.class,
+				() -> service.getDataToSign(documentToSign, signatureParameters));
+		assertTrue(exception.getMessage().contains("Multi-widget signatures"), exception.getMessage());
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/PdfBoxSignatureService.java
@@ -227,25 +227,38 @@ public class PdfBoxSignatureService extends AbstractPDFSignatureService {
 			options.setPreferredSignatureSize(parameters.getContentSize());
 
 			SignatureImageParameters imageParameters = parameters.getImageParameters();
+			boolean multiWidget = Utils.isCollectionNotEmpty(imageParameters.getAdditionalFieldParameters());
+			PdfBoxSignatureDrawer signatureDrawer = null;
 			if (!imageParameters.isEmpty()) {
-				PdfBoxSignatureDrawer signatureDrawer = (PdfBoxSignatureDrawer) loadSignatureDrawer(imageParameters);
+				signatureDrawer = (PdfBoxSignatureDrawer) loadSignatureDrawer(imageParameters);
 				signatureDrawer.init(imageParameters, pdDocument, options);
 				if (signatureDrawer instanceof NativePdfBoxVisibleSignatureDrawer) {
 					((NativePdfBoxVisibleSignatureDrawer) signatureDrawer).setResourcesHandlerBuilder(resourcesHandlerBuilder);
 				}
-				
+
 				if (pdSignatureField == null) {
-					// check signature field position only for new annotations
-					getVisibleSignatureFieldBoxPosition(signatureDrawer, documentReader, fieldParameters);
+					// check signature field position only for new annotations (primary + additional widgets)
+					assertSignatureFieldsPositionValid(signatureDrawer, documentReader, imageParameters);
+				} else if (multiWidget) {
+					throw new IllegalArgumentException(
+							"Additional signature field widgets are not supported when signing an existing signature field!");
 				}
 
 				int page = fieldParameters.getPage();
 				options.setPage(page - ImageUtils.DEFAULT_FIRST_PAGE); // DSS-1138
-				
+
 				signatureDrawer.draw();
+
+			} else if (multiWidget) {
+				throw new IllegalArgumentException(
+						"Additional signature field widgets require a visible signature (image or text parameters)!");
 			}
 
 			pdDocument.addSignature(pdSignature, signatureInterface, options);
+
+			if (multiWidget) {
+				addAdditionalWidgets(pdDocument, pdSignature, signatureDrawer, imageParameters);
+			}
 
 			// the document needs to have an ID, if not the current system time is used, 
 			// and then the digest of the signed data will be different
@@ -295,6 +308,136 @@ public class PdfBoxSignatureService extends AbstractPDFSignatureService {
 			PDAcroForm acroForm = pdDocument.getDocumentCatalog().getAcroForm();
 			if (acroForm != null) {
 				return acroForm.getField(fieldId);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Adds the additional widgets of a multi-widget signature to the signature field created for {@code pdSignature}.
+	 * The signature field (merged with its primary widget by PDFBox) is first converted to a field with a /Kids
+	 * array, then a widget is added for each additional field, sharing the same signature value and the same visual
+	 * appearance as the primary widget (differing only in position, dimensions, page and rotation).
+	 *
+	 * @param pdDocument {@link PDDocument} document being signed
+	 * @param pdSignature {@link PDSignature} signature dictionary of the created signature
+	 * @param signatureDrawer {@link PdfBoxSignatureDrawer} used to build the shared visual appearance
+	 * @param imageParameters {@link SignatureImageParameters} defining the primary and additional fields
+	 * @throws IOException if an exception occurs
+	 */
+	private void addAdditionalWidgets(PDDocument pdDocument, PDSignature pdSignature, PdfBoxSignatureDrawer signatureDrawer,
+									  SignatureImageParameters imageParameters) throws IOException {
+		if (signatureDrawer == null) {
+			throw new IllegalArgumentException(
+					"Additional signature field widgets require a visible signature (image or text parameters)!");
+		}
+		PDSignatureField signatureField = findSignatureFieldByValue(pdDocument, pdSignature);
+		if (signatureField == null) {
+			throw new DSSException("Unable to find the created signature field to add additional widgets to!");
+		}
+
+		COSDictionary fieldDictionary = signatureField.getCOSObject();
+		int primaryPage = imageParameters.getFieldParameters().getPage();
+
+		// Convert the merged field/widget into a field with a /Kids array holding the primary widget
+		COSArray kids = splitMergedFieldWidget(pdDocument, fieldDictionary, primaryPage);
+
+		for (SignatureFieldParameters additionalFieldParameters : imageParameters.getAdditionalFieldParameters()) {
+			AnnotationBox annotationBox = buildSignatureFieldBox(signatureDrawer, additionalFieldParameters);
+			if (annotationBox == null) {
+				throw new DSSException("Unable to compute the position of an additional signature field widget!");
+			}
+			PDAppearanceDictionary appearance = signatureDrawer.buildWidgetAppearance(pdDocument, additionalFieldParameters);
+
+			PDPage page = pdDocument.getPage(additionalFieldParameters.getPage() - ImageUtils.DEFAULT_FIRST_PAGE);
+			PDRectangle rect = new PDRectangle(annotationBox.getMinX(), annotationBox.getMinY(),
+					annotationBox.getWidth(), annotationBox.getHeight());
+
+			PDAnnotationWidget widget = new PDAnnotationWidget();
+			widget.setRectangle(rect);
+			widget.setPage(page);
+			widget.setAppearance(appearance);
+			widget.setPrinted(true);
+			COSDictionary widgetDictionary = widget.getCOSObject();
+			widgetDictionary.setItem(COSName.PARENT, fieldDictionary);
+
+			kids.add(widgetDictionary);
+			page.getAnnotations().add(widget);
+
+			widgetDictionary.setNeedToBeUpdated(true);
+			page.getCOSObject().setNeedToBeUpdated(true);
+			COSArray annots = page.getCOSObject().getCOSArray(COSName.ANNOTS);
+			if (annots != null) {
+				annots.setNeedToBeUpdated(true);
+			}
+		}
+
+		kids.setNeedToBeUpdated(true);
+		fieldDictionary.setNeedToBeUpdated(true);
+	}
+
+	/**
+	 * Converts a merged signature field/widget dictionary into a field with a /Kids array containing a single
+	 * separate widget (the primary widget), as required by the PDF specification when a field has multiple widgets.
+	 *
+	 * @param pdDocument {@link PDDocument} document being signed
+	 * @param fieldDictionary {@link COSDictionary} of the (merged) signature field
+	 * @param primaryPage the page number (1-based) of the primary widget
+	 * @return {@link COSArray} the created /Kids array (already containing the primary widget)
+	 */
+	private COSArray splitMergedFieldWidget(PDDocument pdDocument, COSDictionary fieldDictionary, int primaryPage) {
+		COSDictionary widgetDictionary = new COSDictionary();
+		widgetDictionary.setItem(COSName.TYPE, COSName.ANNOT);
+		widgetDictionary.setItem(COSName.SUBTYPE, COSName.WIDGET);
+		// move the widget-specific entries from the merged field dictionary to the separate widget
+		moveItem(fieldDictionary, widgetDictionary, COSName.RECT);
+		moveItem(fieldDictionary, widgetDictionary, COSName.AP);
+		moveItem(fieldDictionary, widgetDictionary, COSName.AS);
+		moveItem(fieldDictionary, widgetDictionary, COSName.P);
+		moveItem(fieldDictionary, widgetDictionary, COSName.F);
+		moveItem(fieldDictionary, widgetDictionary, COSName.MK);
+		moveItem(fieldDictionary, widgetDictionary, COSName.BS);
+		moveItem(fieldDictionary, widgetDictionary, COSName.getPDFName("Border"));
+		// the field itself is no longer a widget
+		fieldDictionary.removeItem(COSName.SUBTYPE);
+		widgetDictionary.setItem(COSName.PARENT, fieldDictionary);
+
+		// replace the merged widget reference by the separate widget in the primary page annotations
+		PDPage page = pdDocument.getPage(primaryPage - ImageUtils.DEFAULT_FIRST_PAGE);
+		COSArray annots = page.getCOSObject().getCOSArray(COSName.ANNOTS);
+		if (annots != null) {
+			for (int i = 0; i < annots.size(); i++) {
+				if (annots.getObject(i) == fieldDictionary) {
+					annots.set(i, widgetDictionary);
+					break;
+				}
+			}
+			annots.setNeedToBeUpdated(true);
+		}
+
+		COSArray kids = new COSArray();
+		kids.add(widgetDictionary);
+		fieldDictionary.setItem(COSName.KIDS, kids);
+
+		widgetDictionary.setNeedToBeUpdated(true);
+		fieldDictionary.setNeedToBeUpdated(true);
+		page.getCOSObject().setNeedToBeUpdated(true);
+		return kids;
+	}
+
+	private void moveItem(COSDictionary source, COSDictionary target, COSName key) {
+		COSBase value = source.getItem(key);
+		if (value != null) {
+			target.setItem(key, value);
+			source.removeItem(key);
+		}
+	}
+
+	private PDSignatureField findSignatureFieldByValue(final PDDocument pdDocument, final PDSignature pdSignature) {
+		for (PDSignatureField signatureField : pdDocument.getSignatureFields()) {
+			PDSignature signature = signatureField.getSignature();
+			if (signature != null && signature.getCOSObject() == pdSignature.getCOSObject()) {
+				return signatureField;
 			}
 		}
 		return null;

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/AbstractPdfBoxSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/AbstractPdfBoxSignatureDrawer.java
@@ -20,6 +20,7 @@
  */
 package eu.europa.esig.dss.pdf.pdfbox.visible;
 
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
 import eu.europa.esig.dss.pades.SignatureImageParameters;
 import eu.europa.esig.dss.pdf.AnnotationBox;
 import eu.europa.esig.dss.pdf.visible.DSSFontMetrics;
@@ -93,19 +94,60 @@ public abstract class AbstractPdfBoxSignatureDrawer implements PdfBoxSignatureDr
 	 * @return {@link SignatureFieldDimensionAndPosition}
 	 */
 	public SignatureFieldDimensionAndPosition buildSignatureFieldBox() {
-		PDPage originalPage = getPage();
+		return buildSignatureFieldBox(parameters.getFieldParameters());
+	}
+
+	/**
+	 * Builds a signature field dimension and position object for the given {@code fieldParameters}, used to
+	 * position an additional widget of a multi-widget signature. The visual appearance is shared with the primary
+	 * field; only position, dimensions, page and rotation of {@code fieldParameters} are taken into account.
+	 *
+	 * @param fieldParameters {@link SignatureFieldParameters} defining the widget position and dimensions
+	 * @return {@link SignatureFieldDimensionAndPosition}
+	 */
+	@Override
+	public SignatureFieldDimensionAndPosition buildSignatureFieldBox(SignatureFieldParameters fieldParameters) {
+		SignatureImageParameters imageParameters = getImageParametersForField(fieldParameters);
+		PDPage originalPage = getPage(fieldParameters);
 		AnnotationBox pageBox = getPageAnnotationBox(originalPage);
-		return new SignatureFieldDimensionAndPositionBuilder(parameters, getDSSFontMetrics(), pageBox,
+		return new SignatureFieldDimensionAndPositionBuilder(imageParameters, getDSSFontMetrics(), pageBox,
 				originalPage.getRotation()).setSignatureFieldAnnotationBox(getSignatureFieldAnnotationBox()).build();
 	}
 
 	/**
-	 * Gets the page to create a new signature field in
+	 * Returns the {@code SignatureImageParameters} to use for building a widget box. Returns the drawer's
+	 * parameters unchanged for the primary field, or a shallow copy with the field parameters replaced for
+	 * an additional field (so the shared appearance is preserved without mutating the original parameters).
+	 *
+	 * @param fieldParameters {@link SignatureFieldParameters} of the targeted widget
+	 * @return {@link SignatureImageParameters}
+	 */
+	private SignatureImageParameters getImageParametersForField(SignatureFieldParameters fieldParameters) {
+		if (fieldParameters == parameters.getFieldParameters()) {
+			return parameters;
+		}
+		SignatureImageParameters imageParameters = new SignatureImageParameters(parameters);
+		imageParameters.setFieldParameters(fieldParameters);
+		return imageParameters;
+	}
+
+	/**
+	 * Gets the page to create the primary signature field in
 	 *
 	 * @return {@link PDPage}
 	 */
 	protected PDPage getPage() {
-		return document.getPage(parameters.getFieldParameters().getPage() - ImageUtils.DEFAULT_FIRST_PAGE);
+		return getPage(parameters.getFieldParameters());
+	}
+
+	/**
+	 * Gets the page to create a signature field widget in, for the given {@code fieldParameters}
+	 *
+	 * @param fieldParameters {@link SignatureFieldParameters} of the targeted widget
+	 * @return {@link PDPage}
+	 */
+	protected PDPage getPage(SignatureFieldParameters fieldParameters) {
+		return document.getPage(fieldParameters.getPage() - ImageUtils.DEFAULT_FIRST_PAGE);
 	}
 
 	/**

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/PdfBoxSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/PdfBoxSignatureDrawer.java
@@ -20,9 +20,11 @@
  */
 package eu.europa.esig.dss.pdf.pdfbox.visible;
 
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
 import eu.europa.esig.dss.pades.SignatureImageParameters;
 import eu.europa.esig.dss.pdf.visible.SignatureDrawer;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureOptions;
 
 import java.io.IOException;
@@ -34,12 +36,27 @@ public interface PdfBoxSignatureDrawer extends SignatureDrawer {
 
 	/**
 	 * Initializes the drawer
-	 * 
+	 *
 	 * @param parameters {@link SignatureImageParameters}
 	 * @param document {@link PDDocument}
 	 * @param signatureOptions {@link SignatureOptions}
 	 * @throws IOException if an exception occurs
 	 */
 	void init(SignatureImageParameters parameters, PDDocument document, SignatureOptions signatureOptions) throws IOException;
+
+	/**
+	 * Builds a normal appearance dictionary for an additional widget of a multi-widget signature, drawing the
+	 * shared visual appearance (image, text, ...) directly into {@code targetDocument} for the position and
+	 * dimensions defined by {@code fieldParameters}.
+	 * <p>
+	 * Unlike {@code #draw()} (which builds the primary widget through {@code SignatureOptions}), this method
+	 * creates the appearance stream inside the target document so that it can be attached to an additional widget.
+	 *
+	 * @param targetDocument {@link PDDocument} document being signed, where the appearance stream is created
+	 * @param fieldParameters {@link SignatureFieldParameters} defining the widget position and dimensions
+	 * @return {@link PDAppearanceDictionary} the built appearance dictionary
+	 * @throws IOException if an exception occurs
+	 */
+	PDAppearanceDictionary buildWidgetAppearance(PDDocument targetDocument, SignatureFieldParameters fieldParameters) throws IOException;
 
 }

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/defaultdrawer/DefaultPdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/defaultdrawer/DefaultPdfBoxVisibleSignatureDrawer.java
@@ -21,13 +21,22 @@
 package eu.europa.esig.dss.pdf.pdfbox.visible.defaultdrawer;
 
 import eu.europa.esig.dss.pades.DSSFont;
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
 import eu.europa.esig.dss.pades.SignatureImageTextParameters;
 import eu.europa.esig.dss.pdf.AnnotationBox;
+import eu.europa.esig.dss.pdf.pdfbox.PdfBoxUtils;
 import eu.europa.esig.dss.pdf.pdfbox.visible.AbstractPdfBoxSignatureDrawer;
 import eu.europa.esig.dss.pdf.visible.ImageUtils;
 import eu.europa.esig.dss.pdf.visible.SignatureFieldDimensionAndPosition;
 import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.visible.PDVisibleSigProperties;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.visible.PDVisibleSignDesigner;
 
@@ -96,6 +105,39 @@ public class DefaultPdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignature
 		signatureProperties.buildSignature();
 
 		signatureOptions.setVisualSignature(signatureProperties);
+	}
+
+	@Override
+	public PDAppearanceDictionary buildWidgetAppearance(PDDocument targetDocument, SignatureFieldParameters fieldParameters)
+			throws IOException {
+		SignatureFieldDimensionAndPosition dimensionAndPosition = buildSignatureFieldBox(fieldParameters);
+
+		BufferedImage image = null;
+		BufferedImage textImage = null;
+		if (parameters.getImage() != null) {
+			image = DefaultImageDrawerUtils.toBufferedImage(parameters.getImage());
+		}
+		if (parameters.getTextParameters() != null && !parameters.getTextParameters().isEmpty()) {
+			textImage = DefaultImageDrawerUtils.createTextImage(parameters, dimensionAndPosition, getDSSFontMetrics());
+		}
+		if (image == null && textImage == null) {
+			throw new IllegalArgumentException("Image or text shall be defined in order to build a visual signature!");
+		}
+
+		BufferedImage bufferedImage = DefaultImageDrawerUtils.mergeImages(image, textImage, dimensionAndPosition, parameters);
+		bufferedImage = DefaultImageDrawerUtils.rotate(bufferedImage, dimensionAndPosition.getGlobalRotation());
+
+		AnnotationBox annotationBox = dimensionAndPosition.getAnnotationBox();
+		PDRectangle rectangle = new PDRectangle(annotationBox.getMinX(), annotationBox.getMinY(),
+				annotationBox.getWidth(), annotationBox.getHeight());
+
+		PDAppearanceDictionary appearance = PdfBoxUtils.createSignatureAppearanceDictionary(targetDocument, rectangle);
+		PDAppearanceStream appearanceStream = appearance.getNormalAppearance().getAppearanceStream();
+		PDImageXObject imageXObject = LosslessFactory.createFromImage(targetDocument, bufferedImage);
+		try (PDPageContentStream cs = new PDPageContentStream(targetDocument, appearanceStream)) {
+			cs.drawImage(imageXObject, 0, 0, annotationBox.getWidth(), annotationBox.getHeight());
+		}
+		return appearance;
 	}
 
 	@Override

--- a/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
+++ b/dss-pades-pdfbox/src/main/java/eu/europa/esig/dss/pdf/pdfbox/visible/nativedrawer/NativePdfBoxVisibleSignatureDrawer.java
@@ -24,6 +24,7 @@ import eu.europa.esig.dss.model.DSSDocument;
 import eu.europa.esig.dss.pades.DSSFileFont;
 import eu.europa.esig.dss.pades.DSSFont;
 import eu.europa.esig.dss.pades.PAdESUtils;
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
 import eu.europa.esig.dss.pades.SignatureImageParameters;
 import eu.europa.esig.dss.pades.SignatureImageTextParameters;
 import eu.europa.esig.dss.pdf.AnnotationBox;
@@ -180,6 +181,23 @@ public class NativePdfBoxVisibleSignatureDrawer extends AbstractPdfBoxSignatureD
 			}
 
 		}
+	}
+
+	@Override
+	public PDAppearanceDictionary buildWidgetAppearance(PDDocument targetDocument, SignatureFieldParameters fieldParameters)
+			throws IOException {
+		SignatureFieldDimensionAndPosition dimensionAndPosition = buildSignatureFieldBox(fieldParameters);
+		PDRectangle rectangle = getPdRectangle(dimensionAndPosition);
+
+		PDAppearanceDictionary appearance = PdfBoxUtils.createSignatureAppearanceDictionary(targetDocument, rectangle);
+		PDAppearanceStream appearanceStream = appearance.getNormalAppearance().getAppearanceStream();
+		try (PDPageContentStream cs = new PDPageContentStream(targetDocument, appearanceStream)) {
+			rotateSignature(cs, rectangle, dimensionAndPosition);
+			setFieldBackground(cs, parameters.getBackgroundColor());
+			setText(cs, dimensionAndPosition, parameters);
+			setImage(cs, targetDocument, dimensionAndPosition, parameters.getImage());
+		}
+		return appearance;
 	}
 
 	private void rotateSignature(PDPageContentStream cs, PDRectangle rectangle,

--- a/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetPdfBoxTest.java
+++ b/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetPdfBoxTest.java
@@ -1,0 +1,159 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * <p>
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * <p>
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * <p>
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.pades.signature.visible;
+
+import eu.europa.esig.dss.enumerations.MimeTypeEnum;
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.VisualSignatureRotation;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.InMemoryDocument;
+import eu.europa.esig.dss.model.SignatureValue;
+import eu.europa.esig.dss.model.ToBeSigned;
+import eu.europa.esig.dss.pades.PAdESSignatureParameters;
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
+import eu.europa.esig.dss.pades.SignatureImageParameters;
+import eu.europa.esig.dss.pades.signature.PAdESService;
+import eu.europa.esig.dss.pdf.IPdfObjFactory;
+import eu.europa.esig.dss.pdf.pdfbox.PdfBoxDefaultObjectFactory;
+import eu.europa.esig.dss.pdf.pdfbox.PdfBoxNativeObjectFactory;
+import eu.europa.esig.dss.test.PKIFactoryAccess;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessRead;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
+import org.apache.pdfbox.pdmodel.interactive.form.PDSignatureField;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the PDF structure produced by a multi-widget PAdES signature with the PDFBox implementation:
+ * a single signature field and signature dictionary, with one widget per configured position/page.
+ */
+class PAdESMultiWidgetPdfBoxTest extends PKIFactoryAccess {
+
+	private PAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+	private DSSDocument image;
+
+	@BeforeEach
+	void init() {
+		documentToSign = new InMemoryDocument(getClass().getResourceAsStream("/empty-two-pages.pdf"));
+
+		signatureParameters = new PAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
+
+		image = new InMemoryDocument(getClass().getResourceAsStream("/small-red.jpg"), "small-red.jpg", MimeTypeEnum.JPEG);
+	}
+
+	@Test
+	void defaultDrawerTest() throws IOException {
+		assertMultiWidgetStructure(new PdfBoxDefaultObjectFactory());
+	}
+
+	@Test
+	void nativeDrawerTest() throws IOException {
+		assertMultiWidgetStructure(new PdfBoxNativeObjectFactory());
+	}
+
+	private void assertMultiWidgetStructure(IPdfObjFactory pdfObjFactory) throws IOException {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(fieldParameters(1, 50, 50, null));
+		SignatureFieldParameters rotated = fieldParameters(1, 50, 250, VisualSignatureRotation.ROTATE_90);
+		imageParameters.setAdditionalFieldParameters(Arrays.asList(
+				rotated, // additional widget on the same page, rotated
+				fieldParameters(2, 50, 50, null))); // additional widget on another page
+		signatureParameters.setImageParameters(imageParameters);
+
+		DSSDocument signedDocument = sign(pdfObjFactory);
+		assertNotNull(signedDocument);
+
+		try (InputStream is = signedDocument.openStream();
+			 RandomAccessRead rar = new RandomAccessReadBuffer(is);
+			 PDDocument pdDocument = Loader.loadPDF(rar)) {
+
+			// a single signature dictionary and a single signature field
+			List<PDSignature> signatures = pdDocument.getSignatureDictionaries();
+			assertEquals(1, signatures.size());
+
+			List<PDSignatureField> signatureFields = pdDocument.getSignatureFields();
+			assertEquals(1, signatureFields.size());
+
+			PDSignatureField signatureField = signatureFields.get(0);
+			List<PDAnnotationWidget> widgets = signatureField.getWidgets();
+			// one widget per configured position (primary + 2 additional)
+			assertEquals(3, widgets.size());
+
+			Set<Integer> pageIndexes = new HashSet<>();
+			for (PDAnnotationWidget widget : widgets) {
+				assertNotNull(widget.getAppearance(), "each widget shall have an appearance dictionary");
+				assertNotNull(widget.getAppearance().getNormalAppearance(), "each widget shall have a normal appearance");
+				assertNotNull(widget.getPage(), "each widget shall reference a page");
+				pageIndexes.add(pdDocument.getPages().indexOf(widget.getPage()));
+			}
+			// widgets are spread over both pages
+			assertTrue(pageIndexes.contains(0), "a widget shall be present on the first page");
+			assertTrue(pageIndexes.contains(1), "a widget shall be present on the second page");
+		}
+	}
+
+	private SignatureFieldParameters fieldParameters(int page, float originX, float originY, VisualSignatureRotation rotation) {
+		SignatureFieldParameters fieldParameters = new SignatureFieldParameters();
+		fieldParameters.setPage(page);
+		fieldParameters.setOriginX(originX);
+		fieldParameters.setOriginY(originY);
+		fieldParameters.setWidth(100);
+		fieldParameters.setHeight(50);
+		fieldParameters.setRotation(rotation);
+		return fieldParameters;
+	}
+
+	private DSSDocument sign(IPdfObjFactory pdfObjFactory) throws IOException {
+		PAdESService service = new PAdESService(getCompleteCertificateVerifier());
+		service.setPdfObjFactory(pdfObjFactory);
+		ToBeSigned dataToSign = service.getDataToSign(documentToSign, signatureParameters);
+		SignatureValue signatureValue = getToken().sign(dataToSign, signatureParameters.getDigestAlgorithm(), getPrivateKeyEntry());
+		return service.signDocument(documentToSign, signatureParameters, signatureValue);
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}

--- a/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetSignatureTest.java
+++ b/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetSignatureTest.java
@@ -1,0 +1,175 @@
+/**
+ * DSS - Digital Signature Services
+ * Copyright (C) 2015 European Commission, provided under the CEF programme
+ * <p>
+ * This file is part of the "DSS - Digital Signature Services" project.
+ * <p>
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * <p>
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package eu.europa.esig.dss.pades.signature.visible;
+
+import eu.europa.esig.dss.alert.exception.AlertException;
+import eu.europa.esig.dss.diagnostic.DiagnosticData;
+import eu.europa.esig.dss.enumerations.MimeTypeEnum;
+import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.InMemoryDocument;
+import eu.europa.esig.dss.model.SignatureValue;
+import eu.europa.esig.dss.model.ToBeSigned;
+import eu.europa.esig.dss.pades.PAdESSignatureParameters;
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
+import eu.europa.esig.dss.pades.SignatureImageParameters;
+import eu.europa.esig.dss.pades.signature.PAdESService;
+import eu.europa.esig.dss.pades.validation.suite.AbstractPAdESTestValidation;
+import eu.europa.esig.dss.validation.reports.Reports;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the creation of a multi-widget PAdES signature with the PDFBox implementation: a single signature whose
+ * visual appearance is displayed in several positions and/or pages at once through several widgets sharing the
+ * same signature field.
+ */
+class PAdESMultiWidgetSignatureTest extends AbstractPAdESTestValidation {
+
+	private PAdESService service;
+	private PAdESSignatureParameters signatureParameters;
+	private DSSDocument documentToSign;
+	private DSSDocument image;
+
+	@BeforeEach
+	void init() {
+		documentToSign = new InMemoryDocument(getClass().getResourceAsStream("/empty-two-pages.pdf"));
+
+		signatureParameters = new PAdESSignatureParameters();
+		signatureParameters.bLevel().setSigningDate(new Date());
+		signatureParameters.setSigningCertificate(getSigningCert());
+		signatureParameters.setCertificateChain(getCertificateChain());
+		signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
+
+		service = new PAdESService(getCompleteCertificateVerifier());
+
+		image = new InMemoryDocument(getClass().getResourceAsStream("/small-red.jpg"), "small-red.jpg", MimeTypeEnum.JPEG);
+	}
+
+	@Test
+	void multiWidgetAcrossPositionsAndPagesTest() throws IOException {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(fieldParameters(1, 50, 50));
+		imageParameters.setAdditionalFieldParameters(Arrays.asList(
+				fieldParameters(1, 50, 200), // additional widget on the same page
+				fieldParameters(2, 50, 50))); // additional widget on another page
+		signatureParameters.setImageParameters(imageParameters);
+
+		DSSDocument signedDocument = sign();
+		assertNotNull(signedDocument);
+
+		Reports reports = verify(signedDocument);
+		DiagnosticData diagnosticData = reports.getDiagnosticData();
+		// a multi-widget signature remains a single signature
+		assertEquals(1, diagnosticData.getSignatures().size());
+		assertTrue(diagnosticData.isBLevelTechnicallyValid(diagnosticData.getFirstSignatureId()));
+	}
+
+	@Test
+	void widgetsOverlapTest() {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(fieldParameters(1, 50, 50));
+		// additional widget overlapping the primary one on the same page
+		imageParameters.setAdditionalFieldParameters(Collections.singletonList(fieldParameters(1, 60, 60)));
+		signatureParameters.setImageParameters(imageParameters);
+
+		Exception exception = assertThrows(AlertException.class, this::sign);
+		assertEquals("Two signature field widgets of the same signature overlap!", exception.getMessage());
+	}
+
+	@Test
+	void widgetOutsidePageTest() {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(fieldParameters(1, 50, 50));
+		// additional widget placed far outside the page dimensions
+		imageParameters.setAdditionalFieldParameters(Collections.singletonList(fieldParameters(1, 5000, 5000)));
+		signatureParameters.setImageParameters(imageParameters);
+
+		Exception exception = assertThrows(AlertException.class, this::sign);
+		assertTrue(exception.getMessage().contains("outside the page dimensions"), exception.getMessage());
+	}
+
+	@Test
+	void noAdditionalWidgetRemainsSingleWidgetTest() throws IOException {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(fieldParameters(1, 50, 50));
+		signatureParameters.setImageParameters(imageParameters);
+
+		DSSDocument signedDocument = sign();
+		assertNotNull(signedDocument);
+
+		Reports reports = verify(signedDocument);
+		DiagnosticData diagnosticData = reports.getDiagnosticData();
+		assertEquals(1, diagnosticData.getSignatures().size());
+		assertTrue(diagnosticData.isBLevelTechnicallyValid(diagnosticData.getFirstSignatureId()));
+	}
+
+	private SignatureFieldParameters fieldParameters(int page, float originX, float originY) {
+		SignatureFieldParameters fieldParameters = new SignatureFieldParameters();
+		fieldParameters.setPage(page);
+		fieldParameters.setOriginX(originX);
+		fieldParameters.setOriginY(originY);
+		fieldParameters.setWidth(100);
+		fieldParameters.setHeight(50);
+		return fieldParameters;
+	}
+
+	private DSSDocument sign() throws IOException {
+		ToBeSigned dataToSign = service.getDataToSign(documentToSign, signatureParameters);
+		SignatureValue signatureValue = getToken().sign(dataToSign, signatureParameters.getDigestAlgorithm(), getPrivateKeyEntry());
+		return service.signDocument(documentToSign, signatureParameters, signatureValue);
+	}
+
+	@Override
+	protected void checkPdfRevision(DiagnosticData diagnosticData) {
+		// skip (different tests)
+	}
+
+	@Override
+	public void validate() {
+		// do nothing
+	}
+
+	@Override
+	protected DSSDocument getSignedDocument() {
+		return null;
+	}
+
+	@Override
+	protected String getSigningAlias() {
+		return GOOD_USER;
+	}
+
+}

--- a/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetSignatureTest.java
+++ b/dss-pades-pdfbox/src/test/java/eu/europa/esig/dss/pades/signature/visible/PAdESMultiWidgetSignatureTest.java
@@ -28,11 +28,14 @@ import eu.europa.esig.dss.model.DSSDocument;
 import eu.europa.esig.dss.model.InMemoryDocument;
 import eu.europa.esig.dss.model.SignatureValue;
 import eu.europa.esig.dss.model.ToBeSigned;
+import eu.europa.esig.dss.model.x509.CertificateToken;
 import eu.europa.esig.dss.pades.PAdESSignatureParameters;
 import eu.europa.esig.dss.pades.SignatureFieldParameters;
 import eu.europa.esig.dss.pades.SignatureImageParameters;
 import eu.europa.esig.dss.pades.signature.PAdESService;
 import eu.europa.esig.dss.pades.validation.suite.AbstractPAdESTestValidation;
+import eu.europa.esig.dss.pki.model.CertEntity;
+import eu.europa.esig.dss.test.pki.CertEntitySignatureTokenConnection;
 import eu.europa.esig.dss.validation.reports.Reports;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +44,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -121,6 +125,84 @@ class PAdESMultiWidgetSignatureTest extends AbstractPAdESTestValidation {
 	}
 
 	@Test
+	void doubleMultiWidgetSignatureTest() throws IOException {
+		// first multi-widget signature
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(fieldParameters(1, 50, 50));
+		imageParameters.setAdditionalFieldParameters(Arrays.asList(
+				fieldParameters(1, 50, 200),
+				fieldParameters(2, 50, 50)));
+		signatureParameters.setImageParameters(imageParameters);
+
+		DSSDocument firstSignedDocument = sign();
+		assertNotNull(firstSignedDocument);
+
+		// second multi-widget signature over the already (multi-widget) signed document, at non-overlapping positions
+		PAdESSignatureParameters secondSignatureParameters = new PAdESSignatureParameters();
+		secondSignatureParameters.bLevel().setSigningDate(new Date());
+		secondSignatureParameters.setSigningCertificate(getSigningCert());
+		secondSignatureParameters.setCertificateChain(getCertificateChain());
+		secondSignatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
+
+		SignatureImageParameters secondImageParameters = new SignatureImageParameters();
+		secondImageParameters.setImage(image);
+		secondImageParameters.setFieldParameters(fieldParameters(1, 300, 50));
+		secondImageParameters.setAdditionalFieldParameters(Collections.singletonList(fieldParameters(2, 300, 50)));
+		secondSignatureParameters.setImageParameters(secondImageParameters);
+
+		DSSDocument secondSignedDocument = sign(firstSignedDocument, secondSignatureParameters);
+		assertNotNull(secondSignedDocument);
+
+		Reports reports = verify(secondSignedDocument);
+		DiagnosticData diagnosticData = reports.getDiagnosticData();
+		// two independent signatures, both valid
+		assertEquals(2, diagnosticData.getSignatures().size());
+		diagnosticData.getSignatures().forEach(signature ->
+				assertTrue(diagnosticData.isBLevelTechnicallyValid(signature.getId())));
+	}
+
+	@Test
+	void singleThenMultiWidgetDifferentSignersTest() throws IOException {
+		// first signer: single-widget signature
+		signatureParameters.setImageParameters(imageParameters(fieldParameters(1, 50, 50), null));
+		DSSDocument firstSignedDocument = sign();
+		assertNotNull(firstSignedDocument);
+
+		// second, different signer: multi-widget signature at non-overlapping positions
+		PAdESSignatureParameters secondSignatureParameters = signatureParameters(ECDSA_USER);
+		secondSignatureParameters.setImageParameters(imageParameters(fieldParameters(1, 300, 50),
+				Collections.singletonList(fieldParameters(2, 50, 50))));
+		DSSDocument secondSignedDocument = signWith(firstSignedDocument, secondSignatureParameters, ECDSA_USER);
+
+		assertTwoValidSignatures(secondSignedDocument);
+	}
+
+	@Test
+	void multiThenSingleWidgetDifferentSignersTest() throws IOException {
+		// first signer: multi-widget signature
+		signatureParameters.setImageParameters(imageParameters(fieldParameters(1, 50, 50),
+				Arrays.asList(fieldParameters(1, 50, 200), fieldParameters(2, 50, 50))));
+		DSSDocument firstSignedDocument = sign();
+		assertNotNull(firstSignedDocument);
+
+		// second, different signer: single-widget signature at a non-overlapping position
+		PAdESSignatureParameters secondSignatureParameters = signatureParameters(ECDSA_USER);
+		secondSignatureParameters.setImageParameters(imageParameters(fieldParameters(1, 300, 50), null));
+		DSSDocument secondSignedDocument = signWith(firstSignedDocument, secondSignatureParameters, ECDSA_USER);
+
+		assertTwoValidSignatures(secondSignedDocument);
+	}
+
+	private void assertTwoValidSignatures(DSSDocument signedDocument) {
+		Reports reports = verify(signedDocument);
+		DiagnosticData diagnosticData = reports.getDiagnosticData();
+		assertEquals(2, diagnosticData.getSignatures().size());
+		diagnosticData.getSignatures().forEach(signature ->
+				assertTrue(diagnosticData.isBLevelTechnicallyValid(signature.getId())));
+	}
+
+	@Test
 	void noAdditionalWidgetRemainsSingleWidgetTest() throws IOException {
 		SignatureImageParameters imageParameters = new SignatureImageParameters();
 		imageParameters.setImage(image);
@@ -136,6 +218,27 @@ class PAdESMultiWidgetSignatureTest extends AbstractPAdESTestValidation {
 		assertTrue(diagnosticData.isBLevelTechnicallyValid(diagnosticData.getFirstSignatureId()));
 	}
 
+	private SignatureImageParameters imageParameters(SignatureFieldParameters primary,
+													 List<SignatureFieldParameters> additional) {
+		SignatureImageParameters imageParameters = new SignatureImageParameters();
+		imageParameters.setImage(image);
+		imageParameters.setFieldParameters(primary);
+		if (additional != null) {
+			imageParameters.setAdditionalFieldParameters(additional);
+		}
+		return imageParameters;
+	}
+
+	private PAdESSignatureParameters signatureParameters(String signerAlias) {
+		CertEntity signer = getCertEntity(signerAlias);
+		PAdESSignatureParameters parameters = new PAdESSignatureParameters();
+		parameters.bLevel().setSigningDate(new Date());
+		parameters.setSigningCertificate(signer.getCertificateToken());
+		parameters.setCertificateChain(signer.getCertificateChain().toArray(new CertificateToken[0]));
+		parameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
+		return parameters;
+	}
+
 	private SignatureFieldParameters fieldParameters(int page, float originX, float originY) {
 		SignatureFieldParameters fieldParameters = new SignatureFieldParameters();
 		fieldParameters.setPage(page);
@@ -147,9 +250,20 @@ class PAdESMultiWidgetSignatureTest extends AbstractPAdESTestValidation {
 	}
 
 	private DSSDocument sign() throws IOException {
-		ToBeSigned dataToSign = service.getDataToSign(documentToSign, signatureParameters);
-		SignatureValue signatureValue = getToken().sign(dataToSign, signatureParameters.getDigestAlgorithm(), getPrivateKeyEntry());
-		return service.signDocument(documentToSign, signatureParameters, signatureValue);
+		return sign(documentToSign, signatureParameters);
+	}
+
+	private DSSDocument sign(DSSDocument document, PAdESSignatureParameters parameters) throws IOException {
+		ToBeSigned dataToSign = service.getDataToSign(document, parameters);
+		SignatureValue signatureValue = getToken().sign(dataToSign, parameters.getDigestAlgorithm(), getPrivateKeyEntry());
+		return service.signDocument(document, parameters, signatureValue);
+	}
+
+	private DSSDocument signWith(DSSDocument document, PAdESSignatureParameters parameters, String signerAlias) throws IOException {
+		CertEntitySignatureTokenConnection token = new CertEntitySignatureTokenConnection(getCertEntity(signerAlias));
+		ToBeSigned dataToSign = service.getDataToSign(document, parameters);
+		SignatureValue signatureValue = token.sign(dataToSign, parameters.getDigestAlgorithm(), token.getKeys().iterator().next());
+		return service.signDocument(document, parameters, signatureValue);
 	}
 
 	@Override

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageParameters.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pades/SignatureImageParameters.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -57,7 +59,19 @@ public class SignatureImageParameters implements Serializable {
 	 * This variable defines a {@code SignatureFieldParameters} like field positions and dimensions
 	 */
 	private SignatureFieldParameters fieldParameters;
-        
+
+	/**
+	 * This variable defines additional {@code SignatureFieldParameters} used to display the same visual
+	 * signature in multiple positions and/or pages within the same signature (multi-widget signature).
+	 * <p>
+	 * Each entry defines an additional widget sharing the same signature value and the same visual appearance
+	 * (image, text, ...) as the primary {@code fieldParameters}, differing only in position, dimensions,
+	 * page and rotation. The {@code fieldId} of an additional field is ignored (a signature field has a single id).
+	 * <p>
+	 * NOTE: multi-widget signatures are currently supported only by the PDFBox implementation.
+	 */
+	private List<SignatureFieldParameters> additionalFieldParameters;
+
 	/**
 	 * This variable defines a percent to zoom the image (100% means no scaling).
 	 * Note: This do not touch zooming of the text representation.
@@ -118,6 +132,26 @@ public class SignatureImageParameters implements Serializable {
 	}
 
 	/**
+	 * Copy constructor. Creates a shallow copy of the given {@code SignatureImageParameters}, copying every
+	 * appearance-related property. The {@code additionalFieldParameters} list is copied into a new list.
+	 *
+	 * @param original {@link SignatureImageParameters} to copy
+	 */
+	public SignatureImageParameters(SignatureImageParameters original) {
+		this.image = original.image;
+		this.fieldParameters = original.fieldParameters;
+		this.additionalFieldParameters = new ArrayList<>(original.getAdditionalFieldParameters());
+		this.zoom = original.zoom;
+		this.backgroundColor = original.backgroundColor;
+		this.dpi = original.dpi;
+		this.legacyDPIHandling = original.legacyDPIHandling;
+		this.alignmentHorizontal = original.alignmentHorizontal;
+		this.alignmentVertical = original.alignmentVertical;
+		this.imageScaling = original.imageScaling;
+		this.textParameters = original.textParameters;
+	}
+
+	/**
 	 * Returns a {@code DSSDocument} image defined for displaying on the signature field
 	 *
 	 * @return {@link DSSDocument} image
@@ -157,6 +191,46 @@ public class SignatureImageParameters implements Serializable {
 	 */
 	public void setFieldParameters(SignatureFieldParameters fieldParameters) {
 		this.fieldParameters = fieldParameters;
+	}
+
+	/**
+	 * Returns a list of additional {@code SignatureFieldParameters} used to display the same visual signature
+	 * in multiple positions/pages within the same signature (multi-widget signature).
+	 * <p>
+	 * The returned list never contains the primary field (see {@code #getFieldParameters()}).
+	 *
+	 * @return a list of additional {@link SignatureFieldParameters} (never {@code null})
+	 */
+	public List<SignatureFieldParameters> getAdditionalFieldParameters() {
+		if (additionalFieldParameters == null) {
+			additionalFieldParameters = new ArrayList<>();
+		}
+		return additionalFieldParameters;
+	}
+
+	/**
+	 * Sets a list of additional {@code SignatureFieldParameters}, allowing to display the same visual signature
+	 * in multiple positions/pages within the same signature (multi-widget signature).
+	 * <p>
+	 * Each additional field shares the same visual appearance as the primary {@code fieldParameters} and differs
+	 * only in position, dimensions, page and rotation. The {@code fieldId} of an additional field is ignored.
+	 * <p>
+	 * NOTE: multi-widget signatures are currently supported only by the PDFBox implementation.
+	 *
+	 * @param additionalFieldParameters a list of additional {@link SignatureFieldParameters}
+	 */
+	public void setAdditionalFieldParameters(List<SignatureFieldParameters> additionalFieldParameters) {
+		this.additionalFieldParameters = additionalFieldParameters;
+	}
+
+	/**
+	 * Adds an additional {@code SignatureFieldParameters} to display the same visual signature in an additional
+	 * position/page within the same signature (multi-widget signature).
+	 *
+	 * @param fieldParameters {@link SignatureFieldParameters} to add
+	 */
+	public void addFieldParameters(SignatureFieldParameters fieldParameters) {
+		getAdditionalFieldParameters().add(fieldParameters);
 	}
 
 	/**
@@ -341,6 +415,7 @@ public class SignatureImageParameters implements Serializable {
 		return "SignatureImageParameters [" +
 				"image=" + image +
 				", fieldParameters=" + fieldParameters +
+				", additionalFieldParameters=" + getAdditionalFieldParameters() +
 				", zoom=" + zoom +
 				", backgroundColor=" + backgroundColor +
 				", dpi=" + dpi +
@@ -360,6 +435,7 @@ public class SignatureImageParameters implements Serializable {
 		return zoom == that.zoom
 				&& Objects.equals(image, that.image)
 				&& Objects.equals(fieldParameters, that.fieldParameters)
+				&& Objects.equals(getAdditionalFieldParameters(), that.getAdditionalFieldParameters())
 				&& Objects.equals(backgroundColor, that.backgroundColor)
 				&& Objects.equals(dpi, that.dpi)
 				&& alignmentHorizontal == that.alignmentHorizontal
@@ -372,6 +448,7 @@ public class SignatureImageParameters implements Serializable {
 	public int hashCode() {
 		int result = Objects.hashCode(image);
 		result = 31 * result + Objects.hashCode(fieldParameters);
+		result = 31 * result + Objects.hashCode(getAdditionalFieldParameters());
 		result = 31 * result + zoom;
 		result = 31 * result + Objects.hashCode(backgroundColor);
 		result = 31 * result + Objects.hashCode(dpi);

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/AbstractPDFSignatureService.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/AbstractPDFSignatureService.java
@@ -865,9 +865,26 @@ public abstract class AbstractPDFSignatureService implements PDFSignatureService
 	 * @throws IOException if an exception occurs
 	 */
 	protected AnnotationBox buildSignatureFieldBox(SignatureDrawer signatureDrawer) throws IOException {
+		return buildSignatureFieldBox(signatureDrawer, null);
+	}
+
+	/**
+	 * Returns a SignatureFieldBox for the given {@code fieldParameters}. Used for a SignatureField position
+	 * validation of a specific widget of a multi-widget signature. When {@code fieldParameters} is null, the
+	 * primary field box is built.
+	 *
+	 * @param signatureDrawer {@link SignatureDrawer}
+	 * @param fieldParameters {@link SignatureFieldParameters} of the targeted widget, or null for the primary field
+	 * @return {@link AnnotationBox}
+	 * @throws IOException if an exception occurs
+	 */
+	protected AnnotationBox buildSignatureFieldBox(SignatureDrawer signatureDrawer,
+												   SignatureFieldParameters fieldParameters) throws IOException {
 		if (signatureDrawer instanceof SignatureFieldBoxBuilder) {
 			SignatureFieldBoxBuilder signatureFieldBoxBuilder = (SignatureFieldBoxBuilder) signatureDrawer;
-			VisualSignatureFieldAppearance signatureFieldBox = signatureFieldBoxBuilder.buildSignatureFieldBox();
+			VisualSignatureFieldAppearance signatureFieldBox = fieldParameters == null
+					? signatureFieldBoxBuilder.buildSignatureFieldBox()
+					: signatureFieldBoxBuilder.buildSignatureFieldBox(fieldParameters);
 			if (signatureFieldBox != null) {
 				return signatureFieldBox.getAnnotationBox();
 			}
@@ -877,6 +894,38 @@ public abstract class AbstractPDFSignatureService implements PDFSignatureService
 					+ "in order to verify a SignatureField position!");
 		}
 		return null;
+	}
+
+	/**
+	 * Checks validity of the positions of all widgets of a (multi-widget) signature: the primary field defined in
+	 * {@code imageParameters} plus its additional fields. Verifies each widget against the page dimensions and the
+	 * existing annotations, and verifies that the widgets of the same signature do not overlap between each other.
+	 *
+	 * @param signatureDrawer {@link SignatureDrawer}
+	 * @param documentReader  {@link PdfDocumentReader}
+	 * @param imageParameters {@link SignatureImageParameters} defining the primary and additional fields
+	 * @throws IOException if an exception occurs
+	 */
+	protected void assertSignatureFieldsPositionValid(SignatureDrawer signatureDrawer, PdfDocumentReader documentReader,
+													  SignatureImageParameters imageParameters) throws IOException {
+		List<AnnotationBox> annotationBoxes = new ArrayList<>();
+		List<Integer> pageNumbers = new ArrayList<>();
+		collectSignatureFieldBox(annotationBoxes, pageNumbers, signatureDrawer, imageParameters.getFieldParameters());
+		for (SignatureFieldParameters additionalFieldParameters : imageParameters.getAdditionalFieldParameters()) {
+			collectSignatureFieldBox(annotationBoxes, pageNumbers, signatureDrawer, additionalFieldParameters);
+		}
+		if (!annotationBoxes.isEmpty()) {
+			pdfSignatureFieldPositionChecker.assertSignatureFieldsPositionValid(documentReader, annotationBoxes, pageNumbers);
+		}
+	}
+
+	private void collectSignatureFieldBox(List<AnnotationBox> annotationBoxes, List<Integer> pageNumbers,
+										  SignatureDrawer signatureDrawer, SignatureFieldParameters fieldParameters) throws IOException {
+		AnnotationBox annotationBox = buildSignatureFieldBox(signatureDrawer, fieldParameters);
+		if (annotationBox != null) {
+			annotationBoxes.add(annotationBox);
+			pageNumbers.add(fieldParameters.getPage());
+		}
 	}
 
 	/**

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/PdfSignatureFieldPositionChecker.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/PdfSignatureFieldPositionChecker.java
@@ -120,6 +120,60 @@ public class PdfSignatureFieldPositionChecker {
     }
 
     /**
+     * This method verifies whether all provided {@code annotationBoxes} (widgets of the same signature) can be
+     * placed within {@code documentReader} on their respective {@code pageNumbers}. In addition to the checks
+     * performed by {@code #assertSignatureFieldPositionValid} for each box, it verifies that the widgets of the
+     * same signature do not overlap between each other.
+     *
+     * @param documentReader {@link PdfDocumentReader} document to create the new signature field in
+     * @param annotationBoxes a list of {@link AnnotationBox} representing the signature field widgets to be created
+     * @param pageNumbers a list of page numbers, one per {@code annotationBox} (same order and size)
+     */
+    public void assertSignatureFieldsPositionValid(PdfDocumentReader documentReader, List<AnnotationBox> annotationBoxes,
+                                                   List<Integer> pageNumbers) {
+        if (annotationBoxes.size() != pageNumbers.size()) {
+            throw new IllegalArgumentException("The number of annotation boxes shall match the number of page numbers!");
+        }
+        for (int i = 0; i < annotationBoxes.size(); i++) {
+            assertSignatureFieldPositionValid(documentReader, annotationBoxes.get(i), pageNumbers.get(i));
+        }
+        checkSignatureFieldWidgetsOverlap(annotationBoxes, pageNumbers);
+    }
+
+    /**
+     * This method verifies whether any two widgets of the same signature placed on the same page overlap
+     *
+     * @param annotationBoxes a list of {@link AnnotationBox} representing the signature field widgets to verify
+     * @param pageNumbers a list of page numbers, one per {@code annotationBox}
+     */
+    protected void checkSignatureFieldWidgetsOverlap(List<AnnotationBox> annotationBoxes, List<Integer> pageNumbers) {
+        for (int i = 0; i < annotationBoxes.size(); i++) {
+            AnnotationBox boxI = annotationBoxes.get(i);
+            if (boxI.getWidth() == 0 || boxI.getHeight() == 0) {
+                // invisible widget
+                continue;
+            }
+            for (int j = i + 1; j < annotationBoxes.size(); j++) {
+                if (pageNumbers.get(i).equals(pageNumbers.get(j))) {
+                    AnnotationBox boxJ = annotationBoxes.get(j);
+                    if (boxJ.getWidth() != 0 && boxJ.getHeight() != 0 && boxI.isOverlap(boxJ)) {
+                        alertOnSignatureFieldWidgetsOverlap();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Executes the alert {@code alertOnSignatureFieldOverlap} for a self-overlap between widgets of the same signature
+     */
+    private void alertOnSignatureFieldWidgetsOverlap() {
+        MessageStatus status = new MessageStatus();
+        status.setMessage("Two signature field widgets of the same signature overlap!");
+        alertOnSignatureFieldOverlap.alert(status);
+    }
+
+    /**
      * This method verifies whether the {@code signatureFieldBox} overlaps
      * with one of the extracted {@code pdfAnnotations}
      *

--- a/dss-pades/src/main/java/eu/europa/esig/dss/pdf/visible/SignatureFieldBoxBuilder.java
+++ b/dss-pades/src/main/java/eu/europa/esig/dss/pdf/visible/SignatureFieldBoxBuilder.java
@@ -20,6 +20,8 @@
  */
 package eu.europa.esig.dss.pdf.visible;
 
+import eu.europa.esig.dss.pades.SignatureFieldParameters;
+
 import java.io.IOException;
 
 /**
@@ -28,13 +30,28 @@ import java.io.IOException;
  *
  */
 public interface SignatureFieldBoxBuilder {
-	
+
 	/**
 	 * Builds a {@code SignatureFieldBox}, defining signature field position and dimension
-	 * 
+	 *
 	 * @return {@link VisualSignatureFieldAppearance}
 	 * @throws IOException if an exception occurs
 	 */
 	VisualSignatureFieldAppearance buildSignatureFieldBox() throws IOException;
+
+	/**
+	 * Builds a {@code SignatureFieldBox} for the given {@code fieldParameters}, defining position and dimension
+	 * of a specific widget of a multi-widget signature. The visual appearance (image, text, ...) is shared with
+	 * the primary field; only position, dimensions, page and rotation of {@code fieldParameters} are used.
+	 * <p>
+	 * The default implementation ignores {@code fieldParameters} and delegates to {@code #buildSignatureFieldBox()}.
+	 *
+	 * @param fieldParameters {@link SignatureFieldParameters} defining the widget position and dimensions
+	 * @return {@link VisualSignatureFieldAppearance}
+	 * @throws IOException if an exception occurs
+	 */
+	default VisualSignatureFieldAppearance buildSignatureFieldBox(SignatureFieldParameters fieldParameters) throws IOException {
+		return buildSignatureFieldBox();
+	}
 
 }


### PR DESCRIPTION
## What

Adds support for **multi-widget PAdES signatures**: a single signature can be displayed
in several positions and/or pages at once, through multiple widget annotations that share
the same signature field — i.e. a single signature value and a single `/ByteRange`.

Typical use case: "sign here on every page" in a single signing operation.

## Why

Until now a PAdES visible signature could only be shown as a single widget on a single
page (`SignatureImageParameters` held one `SignatureFieldParameters`). There was no way for
the *same* signature to appear in multiple places, which is a common requirement.

## Changes

**API — backward compatible**
- `SignatureImageParameters` gains `additionalFieldParameters` (plus a convenience
  `addFieldParameters(...)` and a copy constructor). The primary `fieldParameters`, existing
  getters/setters and `serialVersionUID` are unchanged; the new getter normalizes `null` to
  an empty list. Each additional widget shares the primary field's visual appearance (image,
  text, ...) and differs only in position, dimensions, page and rotation.

**Core (`dss-pades`)**
- `PdfSignatureFieldPositionChecker`: validates every widget box and additionally detects
  overlap between widgets of the same signature.
- `AbstractPDFSignatureService`: builds a field box per widget and validates all widgets of
  a signature jointly.

**PDFBox (`dss-pades-pdfbox`) — fully supported**
- The merged signature field/widget is split into a `/Kids` structure and one widget is added
  per additional field, drawn into the signed document; the drawers expose
  `buildWidgetAppearance` to render the shared appearance for each widget.

**OpenPDF (`dss-pades-openpdf`) — not supported (yet)**
- Throws a clear `UnsupportedOperationException` when additional fields are set. OpenPDF's
  `PdfSignatureAppearance` creates the field/widget inside `preClose()` where the signed
  `/ByteRange` is fixed, so extra widgets cannot be attached within the single-pass signing
  flow. A two-revision approach is documented in code as a follow-up.

## Backward compatibility

Fully backward compatible. Existing code using a single `fieldParameters` is unaffected; no
public signatures were removed or changed.

## Testing

- Multi-widget across positions and pages (single valid signature, widgets on several pages).
- Overlap between own widgets and widget outside page bounds are rejected.
- Structure check on the produced PDF (single signature dictionary, single field, one widget
  per position), for both the default and native drawers, including per-widget rotation.
- Signing an already multi-widget-signed document again — same signer, and a second different
  signer (single→multi and multi→single) — both signatures remain valid.
- OpenPDF: unsupported-operation test.
- No regression: the existing PDFBox and OpenPDF visible-signature test suites pass.

The cookbook (PAdES visible signature annex) documents the feature with a snippet.

## Note

This contribution was developed with the assistance of an AI coding tool (Claude Code);